### PR TITLE
PoC: Generate & manage jwks via CustomResource

### DIFF
--- a/adr/0001-JwksBootstrapping.md
+++ b/adr/0001-JwksBootstrapping.md
@@ -1,0 +1,33 @@
+# 0001 - JSON Web Key Set bootstrapping
+
+## Status
+Complete
+
+## Decision
+
+Option 2: Scheduled execution. 
+We'll use an EventBridge schedule to generate the JSON web key set every hour on the hour.
+
+The longer term preference is to use Custom Resources. This isn't currently possible because our L1 stack contains resources managed by DevPlatform which not include the permissions for the use of custom resources. This work has been requested and will be available once PLAT-998 is included in a release. To switch we'll need to upgrade our platform to that version.
+
+## Context
+
+The sharing of public keys is done via the well-known endpoint `/.well-known/jwks.json`, which hosts our public key material in a JSON Web Key Set (JWKS), an object containing a list of `keys` that match the [JSON Web Keys](https://www.rfc-editor.org/rfc/rfc7517) format. This is part of the [OIDC provider metadata](https://openid.net/specs/openid-connect-discovery-1_0-21.html#ProviderMetadata) we make available for clients.
+
+Our implementation of this generates a jwks.json file via a lambda, and stores it in S3. We then serve that file via an S3 proxy integration in API Gateway. This minimises the cost of regenerating public key material on demand, and prevents us hitting KMS usage limits if our JWKS endpoint is under heavy usage. The drawback to this is that the initial creation of a JWKS file needs to be triggered on the redeployment of our key configuration. This is currently not automated and requires a manual trigger done by an SRE for the account. For higher environments this manual process is considered unacceptable.
+
+## Options
+### Option 1 - Custom resource trigger
+Use a lambda backed custom resource to trigger the lambda on deployment events `CREATE` and `UPDATE`. 
+See Documentation on [custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html).
+
+### Option 2 - CRON schedule using EventBridge
+Configure an EventBridge rule to run on a schedule. This rule will regenerate the file every X minutes.
+See documentation on [rules configured to run on a schedule](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html).
+
+### Option 3 - Code Deploy pipeline Post-deployment step
+Use the 'AllAtOnce' DeploymentPreference and a PostTraffic Hook.
+See [the developer guide for automating updates to serverless apps](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html) for details.
+
+## Consequences
+This removes manual steps in our deployment process and ensures the JWKS file we provide is kept up to date with any changes in configuration we make to the lambda which generates our JWKS.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,11 @@
+# Title
+
+## Status (mandatory if superseded)
+
+## Decision
+
+## Context
+
+## Options
+
+## Consequences

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -826,6 +826,15 @@ Resources:
         EntryPoints:
           - JwksHandler.ts
 
+  JwksCustomResource:
+    Type: "AWS::CloudFormation::CustomResource"
+    Properties:
+      ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${JsonWebKeysFunction}"
+      StackName: !Ref 'AWS::StackName'
+    DependsOn: 
+      - JsonWebKeysFunction
+      - JsonWebKeysBucket
+    
   JsonWebKeysLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/src/JwksHandler.ts
+++ b/src/JwksHandler.ts
@@ -4,10 +4,14 @@ import { HttpCodesEnum } from "./utils/HttpCodesEnum";
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
 import { Constants } from "./utils/Constants";
 import { Jwk, JWKSBody, Algorithm } from "./utils/IVeriCredential";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 import crypto from "crypto";
 import * as AWS from "@aws-sdk/client-kms";
+import { CloudFormationCustomResourceEvent, CloudFormationCustomResourceFailedResponse, CloudFormationCustomResourceSuccessResponse, Context } from "aws-lambda";
+import https from "https";
+import url from "url";
+import { IncomingMessage } from "http";
 
 const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL ? process.env.POWERTOOLS_LOG_LEVEL : "DEBUG";
 const POWERTOOLS_SERVICE_NAME = process.env.POWERTOOLS_SERVICE_NAME ? process.env.POWERTOOLS_SERVICE_NAME : Constants.JWKS_LOGGER_SVC_NAME;
@@ -35,42 +39,67 @@ const kmsClient = new AWS.KMS({
 
 class JwksHandler implements LambdaInterface {
 
-	async handler(): Promise<string> {
-		if (!SIGNING_KEY_IDS || !ENCRYPTION_KEY_IDS || !JWKS_BUCKET_NAME) {
-			logger.error({ message:"Environment variable SIGNING_KEY_IDS or ENCRYPTION_KEY_IDS or JWKS_BUCKET_NAME is not configured" });
-			throw new AppError("Service incorrectly configured", HttpCodesEnum.SERVER_ERROR );
-		}
-		const body: JWKSBody = { keys: [] };
-		const kmsKeyIds = [
-			...SIGNING_KEY_IDS.split(","),
-			...ENCRYPTION_KEY_IDS.split(","),
-		];
-		logger.info({ message:"Building wellknown JWK endpoint with keys" + kmsKeyIds });
-
-		const jwks = await Promise.all(
-			kmsKeyIds.map(async id => getAsJwk(id)),
-		);
-		jwks.forEach(jwk => {
-			if (jwk != null) {
-				body.keys.push(jwk);
-			} else logger.warn({ message:"Environment contains missing keys" });
-		});
-
-		const uploadParams = {
-			Bucket: JWKS_BUCKET_NAME,
-			Key: ".well-known/jwks.json",
-			Body: JSON.stringify(body),
-			ContentType: "application/json",
-		};
-
+	async handler(event: CloudFormationCustomResourceEvent): Promise<CloudFormationCustomResourceFailedResponse | CloudFormationCustomResourceSuccessResponse> {
 		try {
-			await s3Client.send(new PutObjectCommand(uploadParams));
+			if (event.RequestType === 'Delete') {
+				const objects: ListObjectsV2CommandOutput = await s3Client.send(new ListObjectsV2Command({ Bucket: JWKS_BUCKET_NAME, MaxKeys: 256 }))
+				objects.Contents?.forEach(async object => {
+					await s3Client.send(new DeleteObjectCommand({
+						Bucket: JWKS_BUCKET_NAME,
+						Key: object.Key,
+					}))
+				});
+			} else {
+				if (!SIGNING_KEY_IDS || !ENCRYPTION_KEY_IDS || !JWKS_BUCKET_NAME) {
+					logger.error({ message: "Environment variable SIGNING_KEY_IDS or ENCRYPTION_KEY_IDS or JWKS_BUCKET_NAME is not configured" });
+					throw new AppError("Service incorrectly configured", HttpCodesEnum.SERVER_ERROR);
+				}
+				const body: JWKSBody = { keys: [] };
+				const kmsKeyIds = [
+					...SIGNING_KEY_IDS.split(","),
+					...ENCRYPTION_KEY_IDS.split(","),
+				];
+				logger.info({ message: "Building wellknown JWK endpoint with keys" + kmsKeyIds });
+
+				const jwks = await Promise.all(
+					kmsKeyIds.map(async id => getAsJwk(id)),
+				);
+				jwks.forEach(jwk => {
+					if (jwk != null) {
+						body.keys.push(jwk);
+					} else logger.warn({ message: "Environment contains missing keys" });
+				});
+
+				const uploadParams = {
+					Bucket: JWKS_BUCKET_NAME,
+					Key: ".well-known/jwks.json",
+					Body: JSON.stringify(body),
+					ContentType: "application/json",
+				};
+				await s3Client.send(new PutObjectCommand(uploadParams));
+			}
+			const result: CloudFormationCustomResourceSuccessResponse = {
+				PhysicalResourceId: `${JWKS_BUCKET_NAME}/.well-known/jwks.json`,
+				StackId: event.StackId,
+				RequestId: event.RequestId,
+				LogicalResourceId: event.LogicalResourceId,
+				Status: 'SUCCESS'
+			}
+			sendResponse(event.ResponseURL, result)
+			return result
 		} catch (err) {
 			logger.error({ message: "Error writing keys to S3 bucket" + err });
-			throw new Error("Error writing keys to S3 bucket");
+			const result: CloudFormationCustomResourceFailedResponse = {
+				PhysicalResourceId: `${JWKS_BUCKET_NAME}/.well-known/jwks.json`,
+				StackId: event.StackId,
+				RequestId: event.RequestId,
+				LogicalResourceId: event.LogicalResourceId,
+				Status: 'FAILED',
+				Reason: 'Error creating jwks file. See logs for details.'
+			}
+			sendResponse(event.ResponseURL, result)
+			return result
 		}
-		return JSON.stringify(body);
-
 	}
 }
 const getAsJwk = async (keyId: string): Promise<Jwk | null> => {
@@ -78,15 +107,15 @@ const getAsJwk = async (keyId: string): Promise<Jwk | null> => {
 	try {
 		kmsKey = await kmsClient.getPublicKey({ KeyId: keyId });
 	} catch (error) {
-		logger.warn({ message:"Failed to fetch key from KMS" }, { error });
+		logger.warn({ message: "Failed to fetch key from KMS" }, { error });
 	}
 
 	const map = getKeySpecMap(kmsKey?.KeySpec);
 	if (
 		kmsKey != null &&
-        map != null &&
-        kmsKey.KeyId != null &&
-        kmsKey.PublicKey != null
+		map != null &&
+		kmsKey.KeyId != null &&
+		kmsKey.PublicKey != null
 	) {
 		const use = kmsKey.KeyUsage === "ENCRYPT_DECRYPT" ? "enc" : "sig";
 		const publicKey = crypto
@@ -125,3 +154,31 @@ const getKeySpecMap = (
 };
 const handlerClass = new JwksHandler();
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);
+
+const sendResponse = (uri: string, body: CloudFormationCustomResourceFailedResponse | CloudFormationCustomResourceSuccessResponse) => {
+	const bodyString = JSON.stringify(body)
+	const parsedUrl = url.parse(uri);
+	const options = {
+		hostname: parsedUrl.hostname,
+		port: 443,
+		path: parsedUrl.path,
+		method: "PUT",
+		headers: {
+			"content-type": "application/json",
+			"content-length": bodyString.length
+		}
+	};
+
+	const request = https.request(options, (res) => {
+		console.log('statusCode:', res.statusCode);
+		console.log('headers:', res.headers);
+		res.on('data', (d) => {
+			console.log(d);
+		});
+		request.on("error", (e) => {
+			console.log(e, 'sad times')
+		});
+	});
+	request.write(bodyString);
+	request.end();
+}


### PR DESCRIPTION
Scoping out the best way to automatically share our keys with consumers. Cloudformation custom resources guarantee regeneration on deployment, and allow for deletion of bucket objects with a stack delete command. Making stack management easier.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-XXX](https://govukverify.atlassian.net/browse/F2F-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks