### PR TITLE
feature added to allow test environment to be specified when running …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 
 ### Environment ###
 **/.env
+*.env

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -4,7 +4,8 @@
  */
 
 const dotenv = require('dotenv');
-dotenv.config();
+dotenv.config({ path: `./.${process.env.ENV}.env` });
+console.log("Env: " + `./.${process.env.ENV}.env`)
 
 export default {
   transform: {

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -5,7 +5,6 @@
 
 const dotenv = require('dotenv');
 dotenv.config({ path: `./.${process.env.ENV}.env` });
-console.log("Env: " + `./.${process.env.ENV}.env`)
 
 export default {
   transform: {

--- a/src/package.json
+++ b/src/package.json
@@ -32,7 +32,9 @@
         "test:e2e": "JEST_JUNIT_OUTPUT_NAME=e2e-report.xml ./node_modules/.bin/jest --test-match '**/tests/api/e2e*.test.ts'",
         "test:infra": "./node_modules/.bin/jest --testMatch '**/infra/?(*.)test.ts' ",
         "api": "./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/",
-        "test:api": "npm run compile && npm run api"
+        "test:api:dev": "export ENV=dev && npm run compile && npm run api",
+        "test:api:build": "export ENV=build && npm run compile && npm run api"
+        
     },
     "devDependencies": {
         "@aws-cdk/assertions": "^1.172.0",


### PR DESCRIPTION
…the api test

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed
Updated the jest configuration to allow the specification of what .evn file should be used when running tests. 

<!-- Describe the changes in detail - the "what"-->

The user will now need to specify as an env variable the .env file they would like to use when running the api test pack (e.g ENV=dev)

### Why did it change
To allow support for running test code against different environments
<!-- Describe the reason these changes were made - the "why" -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks