### PR TITLE
KIWI-1320: Github migration - Post-migration cleanup for CIC API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-cic-api repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-api-codeowners
+* @govuk-one-login/kiwi-api-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-api-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-api-codeowners

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
 
 ## Proposed changes
 
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [F2F-XXX](https://govukverify.atlassian.net/browse/F2F-XXX)
+- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)
 
 ## Checklists
 

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
     "name": "CIC",
     "version": "1.0.0",
     "description": "OneLogin CIC CRI",
-    "repository": "https://github.com/alphagov/di-ipv-cri-cic-api",
+    "repository": "https://github.com/govuk-one-login/ipv-cri-cic-api",
     "author": "GDS",
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github CIC API
- Modified the urls pointing to alphagov github repository

- [F2F-1320](https://govukverify.atlassian.net/browse/F2F-1320)