### PR TITLE
[KIWI-933] - Update session state checks in Authorization Lambda

### DIFF
--- a/src/services/AuthorizationRequestProcessor.ts
+++ b/src/services/AuthorizationRequestProcessor.ts
@@ -69,9 +69,17 @@ export class AuthorizationRequestProcessor {
 					});
 					return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
 			  case AuthSessionState.CIC_DATA_RECEIVED:
+					break;
 			  case AuthSessionState.CIC_AUTH_CODE_ISSUED:
 			  case AuthSessionState.CIC_ACCESS_TOKEN_ISSUED:
-					break;
+					this.logger.info(`Duplicate request for session in state: ${session.authSessionState}, returning authCode from DB`, sessionId);
+					return new Response(HttpCodesEnum.OK, JSON.stringify({
+						authorizationCode: {
+							value: session.authorizationCode,
+						},
+						redirect_uri: session?.redirectUri,
+						state: session?.state,
+					}));
 				default:
 					this.logger.error(`Session is in an unexpected state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 
 						messageCode: MessageCodes.INCORRECT_SESSION_STATE,

--- a/src/services/AuthorizationRequestProcessor.ts
+++ b/src/services/AuthorizationRequestProcessor.ts
@@ -63,11 +63,6 @@ export class AuthorizationRequestProcessor {
 			this.metrics.addMetric("found session", MetricUnits.Count, 1);
 
 			switch (session.authSessionState) {
-			  case AuthSessionState.CIC_SESSION_CREATED:
-					this.logger.error(`Session is in the wrong state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 
-						messageCode: MessageCodes.INCORRECT_SESSION_STATE,
-					});
-					return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
 			  case AuthSessionState.CIC_DATA_RECEIVED:
 					break;
 			  case AuthSessionState.CIC_AUTH_CODE_ISSUED:

--- a/src/services/AuthorizationRequestProcessor.ts
+++ b/src/services/AuthorizationRequestProcessor.ts
@@ -62,11 +62,21 @@ export class AuthorizationRequestProcessor {
 
 			this.metrics.addMetric("found session", MetricUnits.Count, 1);
 
-			if (session.authSessionState !== AuthSessionState.CIC_DATA_RECEIVED) {
-				this.logger.error(`Session is in the wrong state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}`, { 
-					messageCode: MessageCodes.INCORRECT_SESSION_STATE,
-				});
-				return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
+			switch (session.authSessionState) {
+			  case AuthSessionState.CIC_SESSION_CREATED:
+					this.logger.error(`Session is in the wrong state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 
+						messageCode: MessageCodes.INCORRECT_SESSION_STATE,
+					});
+					return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
+			  case AuthSessionState.CIC_DATA_RECEIVED:
+			  case AuthSessionState.CIC_AUTH_CODE_ISSUED:
+			  case AuthSessionState.CIC_ACCESS_TOKEN_ISSUED:
+					break;
+				default:
+					this.logger.error(`Session is in an unexpected state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 
+						messageCode: MessageCodes.INCORRECT_SESSION_STATE,
+					});
+					return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
 			}
 
 			// add govuk_signin_journey_id to all subsequent log messages

--- a/src/services/ClaimedIdRequestProcessor.ts
+++ b/src/services/ClaimedIdRequestProcessor.ts
@@ -83,7 +83,7 @@ export class ClaimedIdRequestProcessor {
 			  case AuthSessionState.CIC_DATA_RECEIVED:
 			  case AuthSessionState.CIC_AUTH_CODE_ISSUED:
 			  case AuthSessionState.CIC_ACCESS_TOKEN_ISSUED:
-					this.logger.info("Duplicate request, returning status 200, sessionId: ", sessionId);
+					this.logger.info(`Duplicate request for session in state: ${session.authSessionState}`, sessionId);
 					return new Response(HttpCodesEnum.OK, "Request already processed");
 				default:
 					this.logger.error(`Session is in an unexpected state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_SESSION_CREATED}, ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 

--- a/src/services/ClaimedIdRequestProcessor.ts
+++ b/src/services/ClaimedIdRequestProcessor.ts
@@ -85,6 +85,11 @@ export class ClaimedIdRequestProcessor {
 			  case AuthSessionState.CIC_ACCESS_TOKEN_ISSUED:
 					this.logger.info("Duplicate request, returning status 200, sessionId: ", sessionId);
 					return new Response(HttpCodesEnum.OK, "Request already processed");
+				default:
+					this.logger.error(`Session is in an unexpected state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_SESSION_CREATED}, ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, { 
+						messageCode: MessageCodes.INCORRECT_SESSION_STATE,
+					});
+					return new Response(HttpCodesEnum.UNAUTHORIZED, `Session is in the wrong state: ${session.authSessionState}`);
 			}
 
 		} else {

--- a/src/tests/unit/services/AuthorizationRequestProcessor.test.ts
+++ b/src/tests/unit/services/AuthorizationRequestProcessor.test.ts
@@ -123,7 +123,7 @@ describe("AuthorizationRequestProcessor", () => {
 		expect(out.body).toBe(`Session is in the wrong state: ${session.authSessionState}`);
 		expect(out.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledWith(
-			`Session is in the wrong state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`,
+			`Session is in an unexpected state: ${session.authSessionState}, expected state should be ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`,
 			{ messageCode: MessageCodes.INCORRECT_SESSION_STATE },
 		);
 	});

--- a/src/tests/unit/services/ClaimedIdRequestProcessor.test.ts
+++ b/src/tests/unit/services/ClaimedIdRequestProcessor.test.ts
@@ -83,7 +83,7 @@ describe("ClaimedIdRequestProcessor", () => {
 
 		expect(mockCicService.getSessionById).toHaveBeenCalledTimes(1);
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
-		expect(logger.info).toHaveBeenCalledWith("Duplicate request, returning status 200, sessionId: ", "1234");
+		expect(logger.info).toHaveBeenCalledWith(`Duplicate request for session in state: ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`, "1234");
 	});
 
 	it("Return an error when session is an unknown state", async () => {

--- a/src/tests/unit/services/ClaimedIdRequestProcessor.test.ts
+++ b/src/tests/unit/services/ClaimedIdRequestProcessor.test.ts
@@ -86,6 +86,20 @@ describe("ClaimedIdRequestProcessor", () => {
 		expect(logger.info).toHaveBeenCalledWith("Duplicate request, returning status 200, sessionId: ", "1234");
 	});
 
+	it("Return an error when session is an unknown state", async () => {
+		const session = getMockSessionItem();
+		mockCicService.getSessionById.mockResolvedValue({ ...session, authSessionState: "UNKNOWN" });
+
+		const out: Response = await claimedIdRequestProcessorTest.processRequest(VALID_CLAIMEDID, "1234");
+
+		expect(mockCicService.getSessionById).toHaveBeenCalledTimes(1);
+		expect(out.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
+		expect(logger.error).toHaveBeenCalledWith(
+			`Session is in an unexpected state: UNKNOWN, expected state should be ${AuthSessionState.CIC_SESSION_CREATED}, ${AuthSessionState.CIC_DATA_RECEIVED}, ${AuthSessionState.CIC_AUTH_CODE_ISSUED} or ${AuthSessionState.CIC_ACCESS_TOKEN_ISSUED}`,
+			{ messageCode: MessageCodes.INCORRECT_SESSION_STATE },
+		);
+	});
+
 	it("Return 401 when session with that session id not found in the DB", async () => {
 		mockCicService.getSessionById.mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Updates the state checks in Authorization Lambda to return a 200 if the session state is CIC_DATA_RECEIVED, CIC_AUTH_CODE_ISSUED or CIC_ACCESS_TOKEN_ISSUED

In Authorization Lambda for a duplicate request rather than generate a new AuthCode we query the DB and return the authCode that's already in the DB 

### Why did it change

As part of https://github.com/govuk-one-login/ipv-cri-cic-api/pull/334 the change was made to claimedIdentity to return 200 to cover scenario when user double clicks or when they go back on the browser and forward again, since then the error was still seen and reason for it was due to the change also needing to be made in the Auth lambda 

**Before**
![Kapture 2023-10-17 at 10 58 27](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/13416125/02a38bf3-b7a7-474f-841f-f964af7ecc61)


**After**
![Kapture 2023-10-17 at 11 25 55](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/13416125/86e1df3e-a8ae-4086-b2d6-b96105f76815)
