### PR TITLE
KIWI-1502:Enable Lambda metrics in Dynatrace

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -70,18 +70,23 @@ Parameters:
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
     dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       logretentionindays: 3
       apiTracingEnabled: true
     build:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       logretentionindays: 3
       apiTracingEnabled: true
     staging:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       logretentionindays: 3
       apiTracingEnabled: true
     integration:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
       logretentionindays: 30
       apiTracingEnabled: false
     production:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables #pragma: allowlist secret
       logretentionindays: 30
       apiTracingEnabled: false
 
@@ -207,6 +212,10 @@ Globals:
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
+    Layers:
+      - !Sub
+        - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}' #pragma: allowlist secret # or PYTHON_LAYER or JAVA_LAYER
+        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
     Timeout: 30 # seconds
     Tracing: Active
     MemorySize: 1024
@@ -214,6 +223,23 @@ Globals:
       - arm64
     Environment:
       Variables:
+        AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
+        DT_CONNECTION_AUTH_TOKEN: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}' #pragma: allowlist secret
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_CONNECTION_BASE_URL: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}' #pragma: allowlist secret
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_CLUSTER_ID: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}' #pragma: allowlist secret
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}' #pragma: allowlist secret
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_TENANT: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}' #pragma: allowlist secret
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
         # These should always be alphabetically organised.
         AWS_STACK_NAME: !Sub ${AWS::StackName} # The AWS Stack Name, as passed into the template.
         POWERTOOLS_LOG_LEVEL: !Ref PowertoolsLogLevel # The LogLevel for the AWS PowerTools LogHelper


### PR DESCRIPTION
## Proposed changes
- Integrate Lambda functions to ingest metrics in dynatrace 

### What changed
- Add dyntrace SSM parameters and inject lambda logs to dynatrace

### Why did it change

- This will allow dynatrace to get lambda metric from the CIC service

### Issue tracking

- [KIWI-1502](https://govukverify.atlassian.net/browse/KIWI-1502)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[KIWI-1502]: https://govukverify.atlassian.net/browse/KIWI-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ