### PR TITLE
KIWI-1497: Fix 4xx and 5xx error alarms with ApiId

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1441,8 +1441,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1456,8 +1456,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Sum
 
@@ -1491,8 +1491,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1506,8 +1506,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Sum
 
@@ -1543,8 +1543,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1564,8 +1564,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1605,8 +1605,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1626,8 +1626,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1665,8 +1665,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1686,8 +1686,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1727,8 +1727,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1748,8 +1748,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1791,8 +1791,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1812,8 +1812,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1853,8 +1853,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1874,8 +1874,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1915,8 +1915,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1936,8 +1936,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1977,8 +1977,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1998,8 +1998,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2039,8 +2039,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2060,8 +2060,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2101,8 +2101,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2122,8 +2122,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2163,8 +2163,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2184,8 +2184,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2225,8 +2225,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2246,8 +2246,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2289,8 +2289,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2310,8 +2310,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2349,8 +2349,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -2370,8 +2370,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 4XXError
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -2413,8 +2413,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2434,8 +2434,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2475,8 +2475,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2496,8 +2496,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2537,8 +2537,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2558,8 +2558,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2599,8 +2599,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2620,8 +2620,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2661,8 +2661,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Sum
         - Id: maxLatency
@@ -2672,8 +2672,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Latency
               Dimensions:
-                - Name: ApiName
-                  Value: !Sub "cic-cri-${AWS::StackName}"
+                - Name: ApiId
+                  Value: !Sub "${CICRestApi}"
             Period: 60
             Stat: Maximum
 


### PR DESCRIPTION
- Existing 4xx and 5xx alarms does not create invocations and errors.

## Proposed changes
- ApiName is configured wrong due to which invocations does not happen
- changed to get ApiId to configure the API gateway

### What changed
- Configured the 5xx and 4xx errors alarms with ApiId

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- ApiName configured incorrect causes a issue with getting invocations

### Issue tracking
- [KIWI-1457](https://govukverify.atlassian.net/browse/KIWI-1457)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks