### PR TITLE
KIWI-1497: Fix API name on 5xx and 4xx Alarms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -467,7 +467,20 @@ Resources:
       StageName: !Ref Environment
       OpenApiVersion: 3.0.1
       AccessLogSetting:
-        Format: "$context.requestId $context.httpMethod $context.path"
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip": "$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path": "$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency",
+          "integrationLatency":"$context.integrationLatency"
+          }
         DestinationArn: !GetAtt CICAPIGatewayAccessLogGroup.Arn
       EndpointConfiguration:
         Type: REGIONAL
@@ -1467,8 +1480,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1482,8 +1495,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Sum
 
@@ -1517,8 +1530,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1532,8 +1545,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Sum
 
@@ -1569,8 +1582,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1590,8 +1603,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1631,8 +1644,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1652,8 +1665,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1691,8 +1704,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1712,8 +1725,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1753,8 +1766,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1774,8 +1787,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 5XXError
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -1817,8 +1830,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1838,8 +1851,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1879,8 +1892,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1900,8 +1913,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1941,8 +1954,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -1962,8 +1975,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2003,8 +2016,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2024,8 +2037,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2065,8 +2078,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2086,8 +2099,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2127,8 +2140,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2148,8 +2161,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2189,8 +2202,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2210,8 +2223,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2251,8 +2264,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2272,8 +2285,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2315,8 +2328,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2336,8 +2349,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2375,8 +2388,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -2396,8 +2409,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: 4XXError
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Resource
                   Value: /token
                 - Name: Stage
@@ -2439,8 +2452,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2460,8 +2473,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2501,8 +2514,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2522,8 +2535,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2563,8 +2576,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2584,8 +2597,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: POST
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2625,8 +2638,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2646,8 +2659,8 @@ Resources:
               Dimensions:
                 - Name: Method
                   Value: GET
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
                 - Name: Stage
                   Value: !Ref Environment
                 - Name: Resource
@@ -2687,8 +2700,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Sum
         - Id: maxLatency
@@ -2698,8 +2711,8 @@ Resources:
               Namespace: AWS/ApiGateway
               MetricName: Latency
               Dimensions:
-                - Name: ApiId
-                  Value: !Sub "${CICRestApi}"
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - CIC Credential Issuer Private API"
             Period: 60
             Stat: Maximum
 


### PR DESCRIPTION
- Existing 4xx and 5xx alarms does not create invocations and errors.

## Proposed changes
- ApiName is configured wrong due to which invocations does not happen
- Add Accesslogsettings to send more metrics

### What changed
- Modified access log settings on the API Gateway.
- Modified API Name confgiuration.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- ApiName configured incorrect causes a issue with getting invocations
- Accesslogsettings require additinal parameters to alerts

### Issue tracking
- [KIWI-1497](https://govukverify.atlassian.net/browse/KIWI-1497)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[KIWI-1457]: https://govukverify.atlassian.net/browse/KIWI-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KIWI-1497]: https://govukverify.atlassian.net/browse/KIWI-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
![Screenshot 2024-01-15 at 11 30 25](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/131283983/693abbf5-0015-4e66-8529-bae378a79b04)

