### PR TITLE
KIWI-1665: Updates CIC_CRI_START event

### DIFF
--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+/* eslint-disable max-lines-per-function */
 import { Response, GenericServerError, unauthorizedResponse, SECURITY_HEADERS } from "../utils/Response";
 import { CicService } from "./CicService";
 import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
@@ -15,7 +17,6 @@ import { ValidationHelper } from "../utils/ValidationHelper";
 import { JwtPayload, Jwt } from "../utils/IVeriCredential";
 import { MessageCodes } from "../models/enums/MessageCodes";
 import { Constants } from "../utils/Constants";
-
 
 interface ClientConfig {
 	jwksEndpoint: string;
@@ -174,7 +175,7 @@ export class SessionRequestProcessor {
 			createdDate: Date.now() / 1000,
 			state: jwtPayload.state,
 			subject: jwtPayload.sub ? jwtPayload.sub : "",
-			persistentSessionId: jwtPayload.persistent_session_id, //Might not be used
+			persistentSessionId: jwtPayload.persistent_session_id, // Might not be used
 			clientIpAddress,
 			attemptCount: 0,
 			authSessionState: "CIC_SESSION_CREATED",
@@ -207,6 +208,11 @@ export class SessionRequestProcessor {
 			await this.cicService.sendToTXMA({
 				event_name: "CIC_CRI_START",
 				...buildCoreEventFields(session, ISSUER as string, session.clientIpAddress, absoluteTimeNow),
+				...(jwtPayload.context && { extensions: {
+					evidence: {
+						context: jwtPayload.context,
+					},
+				} }),
 			});
 		} catch (error) {
 			this.logger.error("Auth session successfully created. Failed to send CIC_CRI_START event to TXMA", {

--- a/src/tests/unit/services/SessionRequestProcessor.test.ts
+++ b/src/tests/unit/services/SessionRequestProcessor.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines-per-function */
+/* eslint @typescript-eslint/unbound-method: 0 */
+/* eslint jest/unbound-method: error */
 import { SessionRequestProcessor } from "../../../services/SessionRequestProcessor";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
@@ -11,15 +14,17 @@ import { Jwt } from "../../../utils/IVeriCredential";
 import { ValidationHelper } from "../../../utils/ValidationHelper";
 import { ISessionItem } from "../../../models/ISessionItem";
 
-/* eslint @typescript-eslint/unbound-method: 0 */
-/* eslint jest/unbound-method: error */
-
 let sessionRequestProcessor: SessionRequestProcessor;
 const mockCicService = mock<CicService>();
 const mockKmsJwtAdapter = mock<KmsJwtAdapter>();
 const logger = mock<Logger>();
 const metrics = mock<Metrics>();
 const mockValidationHelper = mock<ValidationHelper>();
+
+jest.mock("crypto", () => ({
+	...jest.requireActual("crypto"),
+	randomUUID: () => "sessionId",
+}));
 
 const decodedJwtFactory = ():Jwt => {
 	return {
@@ -74,13 +79,8 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report unrecognised client", async () => {
-
-		// Arrange
-
-		// Act
 		const response = await sessionRequestProcessor.processRequest(SESSION_WITH_INVALID_CLIENT);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.BAD_REQUEST);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -92,14 +92,10 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report a JWE decryption failure", async () => {
-
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockRejectedValue("error");
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -111,17 +107,13 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report a failure to decode JWT", async () => {
-
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockImplementation(() => {
 			throw Error("Error");
 		});
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -133,16 +125,12 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report a JWT verification failure", async () => {
-
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(null);
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -154,16 +142,12 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report an unexpected error verifying JWT", async () => {
-
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockRejectedValue({});
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -175,17 +159,13 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report a JWT validation failure", async () => {
-
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
 		mockValidationHelper.isJwtValid.mockReturnValue("errors");
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
@@ -196,17 +176,14 @@ describe("SessionRequestProcessor", () => {
 	});
 
 	it("should report session already exists", async () => {
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
 		mockValidationHelper.isJwtValid.mockReturnValue("");
 		mockCicService.getSessionById.mockResolvedValue(sessionItemFactory());
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
@@ -216,13 +193,12 @@ describe("SessionRequestProcessor", () => {
 		);
 		expect(response.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: expect.any(String),
+			sessionId: "sessionId",
 			govuk_signin_journey_id: "abcdef",
 		});
 	});
 
-	it("should fail to create a session", async () => {
-		// Arrange
+	it("should handle session creation failure", async () => {
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
@@ -230,10 +206,8 @@ describe("SessionRequestProcessor", () => {
 		mockCicService.getSessionById.mockResolvedValue(undefined);
 		mockCicService.createAuthSession.mockRejectedValue("error");
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
@@ -243,13 +217,12 @@ describe("SessionRequestProcessor", () => {
 		);
 		expect(response.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: expect.any(String),
+			sessionId: "sessionId",
 			govuk_signin_journey_id: "abcdef",
 		});
 	});
 
 	it("should create a new session", async () => {
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
@@ -257,19 +230,16 @@ describe("SessionRequestProcessor", () => {
 		mockCicService.getSessionById.mockResolvedValue(undefined);
 		mockCicService.createAuthSession.mockResolvedValue();
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.OK);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: expect.any(String),
+			sessionId: "sessionId",
 			govuk_signin_journey_id: "abcdef",
 		});
 	});
 
 	it("should create a new session but report a TxMA failure", async () => {
-		// Arrange
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
@@ -278,10 +248,8 @@ describe("SessionRequestProcessor", () => {
 		mockCicService.createAuthSession.mockResolvedValue();
 		mockCicService.sendToTXMA.mockRejectedValue("failed");
 
-		// Act
 		const response = await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
 		expect(response.statusCode).toBe(HttpCodesEnum.OK);
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith(
@@ -291,28 +259,87 @@ describe("SessionRequestProcessor", () => {
 			}),
 		);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: expect.any(String),
+			sessionId: "sessionId",
 			govuk_signin_journey_id: "abcdef",
 		});
 	});
 
-	it("the session created should have a valid expiryDate", async () => {
-		// Arrange
+	it("should send correct TXMA event", async () => {
 		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
 		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
 		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
 		mockValidationHelper.isJwtValid.mockReturnValue("");
 		mockCicService.getSessionById.mockResolvedValue(undefined);
 		mockCicService.createAuthSession.mockResolvedValue();
-		mockCicService.savePersonIdentity.mockRejectedValue("error");
 		jest.useFakeTimers();
 		const fakeTime = 1684933200;
 		jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
 
-		// Act
 		await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		// Assert
+		expect(mockCicService.sendToTXMA).toHaveBeenCalledWith({
+			event_name: "CIC_CRI_START",
+			client_id: undefined,
+			component_id: "https://XXX-c.env.account.gov.uk",
+			timestamp: 1684933200,
+			user: {
+				govuk_signin_journey_id: "abcdef",
+				ip_address: "",
+				persistent_session_id: undefined,
+				session_id: "sessionId",
+				transaction_id: "",
+				user_id: "",
+			},
+		});
+	});
+
+	it("should send correct TXMA event where context is provided in JWT", async () => {
+		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
+		mockKmsJwtAdapter.decode.mockReturnValue({ ...decodedJwtFactory(), payload: { ...decodedJwtFactory().payload, context: "bank_account" } });
+		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
+		mockValidationHelper.isJwtValid.mockReturnValue("");
+		mockCicService.getSessionById.mockResolvedValue(undefined);
+		mockCicService.createAuthSession.mockResolvedValue();
+		jest.useFakeTimers();
+		const fakeTime = 1684933200;
+		jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
+
+		await sessionRequestProcessor.processRequest(VALID_SESSION);
+
+		expect(mockCicService.sendToTXMA).toHaveBeenCalledWith({
+			event_name: "CIC_CRI_START",
+			client_id: undefined,
+			component_id: "https://XXX-c.env.account.gov.uk",
+			timestamp: 1684933200,
+			user: {
+				govuk_signin_journey_id: "abcdef",
+				ip_address: "",
+				persistent_session_id: undefined,
+				session_id: "sessionId",
+				transaction_id: "",
+				user_id: "",
+			},
+			extensions: {
+				evidence: {
+					context: "bank_account",
+				},
+			},
+		});
+	});
+
+	it("the session created should have a valid expiryDate", async () => {
+		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
+		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
+		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
+		mockValidationHelper.isJwtValid.mockReturnValue("");
+		mockCicService.getSessionById.mockResolvedValue(undefined);
+		mockCicService.createAuthSession.mockResolvedValue();
+		jest.useFakeTimers();
+		const fakeTime = 1684933200;
+		jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
+
+		await sessionRequestProcessor.processRequest(VALID_SESSION);
+
 		expect(mockCicService.createAuthSession).toHaveBeenNthCalledWith(
 			1,
 			expect.objectContaining({

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -17,6 +17,14 @@ export interface TxmaUser {
 	"ip_address"?: string | undefined;
 }
 
+export interface Evidence {
+	"context": string;
+}
+
+export interface Extensions {
+	"evidence": Evidence;
+}
+
 export interface BaseTxmaEvent {
 	"user": TxmaUser;
 	"client_id": string;
@@ -27,6 +35,7 @@ export interface BaseTxmaEvent {
 export interface TxmaEvent extends BaseTxmaEvent {
 	"event_name": TxmaEventName;
 	"restricted"?: VerifiedCredential["credentialSubject"];
+	"extensions"?: Extensions;
 }
 
 export const buildCoreEventFields = (


### PR DESCRIPTION
## Proposed changes

### What changed

Updates CIC_CRI_START event to include context if one is provided in the JWT

### Why did it change

Needed for no photo ID

### Screenshots

Photo ID journey
![Screenshot 2024-02-22 at 12 00 25 pm](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/40401118/601ddb24-c2b6-4f7b-8545-f0ec3cbe556f)

No photo ID journey
![Screenshot 2024-02-22 at 12 00 45 pm](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/40401118/de38b752-2e1b-4241-91ab-1755a389983b)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1665](https://govukverify.atlassian.net/browse/KIWI-1665)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged