### PR TITLE
KIWI-1658-abort endpoint-QA

### DIFF
--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -199,6 +199,26 @@ export async function getKeyFromSession(sessionId: string, tableName: string, ke
 		throw new Error("getKeyFromSession - Failed to get " + key + " value: " + e);
 	}
 }
+export async function getSessionAndVerifyKey(sessionId: string, tableName: string, key: string, expectedValue: string): Promise<void> {
+	const sessionInfo = await getSessionById(sessionId, tableName);
+	try {
+		expect(sessionInfo![key as keyof ISessionItem]).toBe(expectedValue);
+	} catch (error: any) {
+		throw new Error("getSessionAndVerifyKey - Failed to verify " + key + " value: " + error);
+	}
+}
+
+export async function abortPost(sessionId: string): Promise<AxiosResponse<string>> {
+	const path = "/abort";
+	try {
+		const postRequest = await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId } });
+		return postRequest;
+	} catch (error: any) {
+		console.log(`Error response from ${path} endpoint: ${error}`);
+		return error.response;
+	}
+}
+
 
 async function validateRawHead(rawHead: any): Promise<void> {
 	const decodeRawHead = JSON.parse(jwtUtils.base64DecodeToString(rawHead.replace(/\W/g, "")));

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -211,8 +211,7 @@ export async function getSessionAndVerifyKey(sessionId: string, tableName: strin
 export async function abortPost(sessionId: string): Promise<AxiosResponse<string>> {
 	const path = "/abort";
 	try {
-		const postRequest = await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId } });
-		return postRequest;
+		return await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId } });
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
 		return error.response;

--- a/src/tests/api/ApiUtils.ts
+++ b/src/tests/api/ApiUtils.ts
@@ -7,6 +7,7 @@ import * as CIC_CRI_START_BANK_ACCOUNT_SCHEMA from "../data/CIC_CRI_START_BANK_A
 import * as CIC_CRI_AUTH_CODE_ISSUED_SCHEMA from "../data/CIC_CRI_AUTH_CODE_ISSUED_SCHEMA.json";
 import * as CIC_CRI_END_SCHEMA from "../data/CIC_CRI_END_SCHEMA.json";
 import * as CIC_CRI_VC_ISSUED_SCHEMA from "../data/CIC_CRI_VC_ISSUED_SCHEMA.json";
+import * as CIC_CRI_SESSION_ABORTED_SCHEMA from "../data/CIC_CRI_SESSION_ABORTED_SCHEMA.json";
 
 const ajv = new Ajv({ strictTuples: false });
 ajv.addSchema(CIC_CRI_START_SCHEMA, "CIC_CRI_START_SCHEMA");
@@ -14,6 +15,7 @@ ajv.addSchema(CIC_CRI_START_BANK_ACCOUNT_SCHEMA, "CIC_CRI_START_BANK_ACCOUNT_SCH
 ajv.addSchema(CIC_CRI_AUTH_CODE_ISSUED_SCHEMA, "CIC_CRI_AUTH_CODE_ISSUED_SCHEMA");
 ajv.addSchema(CIC_CRI_END_SCHEMA, "CIC_CRI_END_SCHEMA");
 ajv.addSchema(CIC_CRI_VC_ISSUED_SCHEMA, "CIC_CRI_VC_ISSUED_SCHEMA");
+ajv.addSchema(CIC_CRI_SESSION_ABORTED_SCHEMA, "CIC_CRI_SESSION_ABORTED_SCHEMA");
 
 const xmlParser = new XMLParser();
 
@@ -26,6 +28,7 @@ interface AllTxmaEvents {
 	"CIC_CRI_AUTH_CODE_ISSUED"?: TxmaEvent;
 	"CIC_CRI_END"?: TxmaEvent;
 	"CIC_CRI_VC_ISSUED"?: TxmaEvent;
+	"CIC_CRI_SESSION_ABORTED"?: TxmaEvent;
 }
 
 const getTxMAS3FileNames = async (prefix: string): Promise<any> => {

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable max-lines-per-function */
+import userData from "../data/happyPathSlim.json";
 import { constants } from "./ApiConstants";
-import { abortPost, getKeyFromSession, getSessionAndVerifyKey, startStubServiceAndReturnSessionId, wellKnownGet } from "./ApiTestSteps";
+import { abortPost, getKeyFromSession, getSessionAndVerifyKey, startStubServiceAndReturnSessionId, wellKnownGet, claimedIdentityPost } from "./ApiTestSteps";
 import { getTxmaEventsFromTestHarness, validateTxMAEventData } from "./ApiUtils";
 
 describe("Happy path tests", () => {
@@ -23,7 +24,7 @@ describe("Happy path tests", () => {
 
 	it("./wellknown/jwks.json endpoint", async () => {
 		const { status, data } = await wellKnownGet();
-			
+
 		expect(status).toBe(200);
 		expect(data.keys).toHaveLength(2);
 		expect(data.keys[0].use).toBe("sig");
@@ -34,33 +35,40 @@ describe("Happy path tests", () => {
 		let sessionId: string;
 
 		beforeEach(async () => {
-			sessionId = await startStubServiceAndReturnSessionId();
+			const sessionResponse = await startStubServiceAndReturnSessionId(userData.journeyType);
+			sessionId = sessionResponse.data.session_id;
 		});
 
 		it("Successful Request Test - Abort After Session Request", async () => {
+			console.log("Session Id: " + sessionId);
 			const response = await abortPost(sessionId);
 			expect(response.status).toBe(200);
 			expect(response.data).toBe("Session has been aborted");
 
-			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "authSessionState", "CIC_CRI_SESSION_ABORTED");
-
-			const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 2);
-			validateTxMAEventData({ eventName: "CIC_CRI_START", schemaName: "CIC_CRI_START_SCHEMA" }, allTxmaEventBodies);
-			validateTxMAEventData({ eventName: "CIC_CRI_SESSION_ABORTED", schemaName: "CIC_CRI_SESSION_ABORTED_SCHEMA" }, allTxmaEventBodies);
-
 			expect(response.headers).toBeTruthy();
 			expect(response.headers.location).toBeTruthy();
 
-			const responseURI = decodeURIComponent(response.headers.location);
-			const responseURIParameters = new URLSearchParams(responseURI);
-			expect(responseURIParameters.has("error")).toBe(true);
-			expect(responseURIParameters.has("state")).toBe(true);
-			expect(responseURIParameters.get("error")).toBe("access_denied");
+			const url = new URL(decodeURIComponent(response.headers.location));
+			expect(url.searchParams.has("error")).toBe(true);
+			expect(url.searchParams.has("state")).toBe(true);
+			expect(url.searchParams.get("error")).toBe("access_denied");
 
-			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + responseURIParameters.get("state"));
+			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "authSessionState", "CIC_CRI_SESSION_ABORTED");
+			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + url.searchParams.get("state"));
+
+			const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 2);
+			console.log(allTxmaEventBodies);
+			validateTxMAEventData({ eventName: "CIC_CRI_START", schemaName: "CIC_CRI_START_SCHEMA" }, allTxmaEventBodies);
+			validateTxMAEventData({ eventName: "CIC_CRI_SESSION_ABORTED", schemaName: "CIC_CRI_SESSION_ABORTED_SCHEMA" }, allTxmaEventBodies);
+
 		});
 
-		it("Successful Request Test - Abort After Verify Account Request", async () => {
+		it("Successful Request Test - Abort After Claimed Identity Request", async () => {
+
+			// Claimed Identity
+			const claimedIdentityResponse = await claimedIdentityPost(userData.firstName, userData.lastName, userData.dateOfBirth, sessionId);
+			expect(claimedIdentityResponse.status).toBe(200);
+
 			const response = await abortPost(sessionId);
 			expect(response.status).toBe(200);
 			expect(response.data).toBe("Session has been aborted");
@@ -84,7 +92,7 @@ describe("Happy path tests", () => {
 
 			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + responseURIParameters.get("state"));
 		});
-	
+
 	});
 });
 

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -41,7 +41,6 @@ describe("Happy path tests", () => {
 		});
 
 		it("Successful Request Test - Abort After Session Request", async () => {
-			console.log("Session Id: " + sessionId);
 			const response = await abortPost(sessionId);
 			expect(response.status).toBe(200);
 			expect(response.data).toBe("Session has been aborted");
@@ -58,7 +57,6 @@ describe("Happy path tests", () => {
 			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + url.searchParams.get("state"));
 
 			const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 2);
-			console.log(allTxmaEventBodies);
 			validateTxMAEventData({ eventName: "CIC_CRI_START", schemaName: "CIC_CRI_START_SCHEMA" }, allTxmaEventBodies);
 			validateTxMAEventData({ eventName: "CIC_CRI_SESSION_ABORTED", schemaName: "CIC_CRI_SESSION_ABORTED_SCHEMA" }, allTxmaEventBodies);
 

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable max-len */
+
 /* eslint-disable max-lines-per-function */
 import userData from "../data/happyPathSlim.json";
 import { constants } from "./ApiConstants";
@@ -73,9 +74,14 @@ describe("Happy path tests", () => {
 			expect(response.status).toBe(200);
 			expect(response.data).toBe("Session has been aborted");
 
+			const url = new URL(decodeURIComponent(response.headers.location));
+			expect(url.searchParams.has("error")).toBe(true);
+			expect(url.searchParams.has("state")).toBe(true);
+			expect(url.searchParams.get("error")).toBe("access_denied");
+
 			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "authSessionState", "CIC_CRI_SESSION_ABORTED");
 
-			const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 4);
+			const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 2);
 
 			validateTxMAEventData({ eventName: "CIC_CRI_START", schemaName: "CIC_CRI_START_SCHEMA" }, allTxmaEventBodies);
 
@@ -84,13 +90,7 @@ describe("Happy path tests", () => {
 			expect(response.headers).toBeTruthy();
 			expect(response.headers.location).toBeTruthy();
 
-			const responseURI = decodeURIComponent(response.headers.location);
-			const responseURIParameters = new URLSearchParams(responseURI);
-			expect(responseURIParameters.has("error")).toBe(true);
-			expect(responseURIParameters.has("state")).toBe(true);
-			expect(responseURIParameters.get("error")).toBe("access_denied");
-
-			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + responseURIParameters.get("state"));
+			await getSessionAndVerifyKey(sessionId, constants.DEV_CIC_SESSION_TABLE_NAME, "state", "" + url.searchParams.get("state"));
 		});
 
 	});

--- a/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
@@ -1,0 +1,56 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "transaction_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "transaction_id",
+                "session_id",
+                "govuk_signin_journey_id",
+                "ip_address"
+            ]
+        },
+        "client_id": {
+            "type": "string"
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "event_timestamp_ms": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "client_id",
+        "timestamp",
+        "event_timestamp_ms",
+        "component_id"
+    ],
+    "additionalProperties": false
+}

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -5,7 +5,8 @@ export type TxmaEventName =
 	"CIC_CRI_START"
 	| "CIC_CRI_AUTH_CODE_ISSUED"
 	| "CIC_CRI_END"
-	| "CIC_CRI_VC_ISSUED";
+	| "CIC_CRI_VC_ISSUED"
+	| "CIC_CRI_SESSION_ABORTED";
 
 export interface TxmaUser {
 	"user_id": string;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Added two tests in `HappyPathTest` 

### Why did it change

To validate the abort endpoints from the Claimed Identity Collector

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1658](https://govukverify.atlassian.net/browse/KIWI-1658)



[KIWI-1658]: https://govukverify.atlassian.net/browse/KIWI-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ