### PR TITLE
[KIWI-1780] - CIC | CloudFront initiative | BE | Add the CF Header for User - Machine Calls

### DIFF
--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -315,6 +315,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SessionRequest'
+      parameters:
+        - $ref: '#/components/parameters/AuditHeader'
       responses:
         "201":
           description: >-
@@ -683,6 +685,8 @@ paths:
               $ref: "#/components/schemas/AbortRequest"
       parameters:
         - $ref: '#/components/parameters/SessionId'
+      parameters:
+        - $ref: '#/components/parameters/AuditHeader'
       tags:
         - Backend - CI CRI specific
       responses:
@@ -1271,6 +1275,13 @@ components:
       description: >-
         `sessionId` as returned by `POST /session` endpoint
       required: true
+    AuditHeader:
+      name: txma-audit-encoded
+      in: header
+      description: An encoded header sent by the FE containing info about request origin
+      required: false
+      schema:
+        type: string
 
 x-amazon-apigateway-request-validators:
     both:

--- a/src/AbortHandler.ts
+++ b/src/AbortHandler.ts
@@ -8,11 +8,12 @@ import { HttpCodesEnum } from "./utils/HttpCodesEnum";
 import { Response, unauthorizedResponse } from "./utils/Response";
 import { AppError } from "./utils/AppError";
 import { AbortRequestProcessor } from "./services/AbortRequestProcessor";
+import { getSessionIdHeaderErrors } from "./utils/Validations";
 
 const POWERTOOLS_METRICS_NAMESPACE = process.env.POWERTOOLS_METRICS_NAMESPACE || Constants.CIC_METRICS_NAMESPACE;
 const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL || "DEBUG";
 const POWERTOOLS_SERVICE_NAME = process.env.POWERTOOLS_SERVICE_NAME || Constants.ABORT_LOGGER_SVC_NAME;
-const logger = new Logger({
+export const logger = new Logger({
 	logLevel: POWERTOOLS_LOG_LEVEL,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
@@ -28,38 +29,9 @@ export class AbortHandler implements LambdaInterface {
 		logger.setPersistentLogAttributes({});
 		logger.addContext(context);
 		try {
-			let sessionId: string;
-			if (event.headers) {
-				sessionId = event.headers[Constants.X_SESSION_ID] as string;
-				logger.appendKeys({ sessionId });
-				if (sessionId) {
-					if (!Constants.REGEX_UUID.test(sessionId)) {
-						logger.error("Session id must be a valid uuid",
-							{
-								messageCode: MessageCodes.INVALID_SESSION_ID,
-							});
-						return unauthorizedResponse;
-					}
-				} else {
-					logger.error("Missing header: session-id is required",
-						{
-							messageCode: MessageCodes.MISSING_SESSION_ID,
-						});
-					return unauthorizedResponse;
-				}
-			} else {
-				logger.error("Empty headers",
-					{
-						messageCode: MessageCodes.EMPTY_HEADERS,
-					});
-				return unauthorizedResponse;
-			}
-
-			logger.info("Starting AbortRequestProcessor",
-				{
-					resource: event.resource,
-				});
-			return await AbortRequestProcessor.getInstance(logger, metrics).processRequest(sessionId);
+			const { sessionId, encodedHeader } = this.validateEvent(event);
+			logger.info("Starting AbortRequestProcessor");
+			return await AbortRequestProcessor.getInstance(logger, metrics).processRequest(sessionId, encodedHeader);
 		} catch (error) {
 			logger.error({ message: "AbortRequestProcessor encountered an error.",
 				error,
@@ -70,6 +42,25 @@ export class AbortHandler implements LambdaInterface {
 			}
 			return new Response(HttpCodesEnum.SERVER_ERROR, "An error has occurred");
 		}
+	}
+
+	validateEvent(event: APIGatewayProxyEvent): { sessionId: string; encodedHeader: string } {
+		if (!event.headers) {			
+			const message = "Invalid request: missing headers";
+			logger.error({ message, messageCode: MessageCodes.MISSING_HEADER });
+			throw new AppError(message, HttpCodesEnum.UNAUTHORIZED);
+		}
+
+		const sessionIdError = getSessionIdHeaderErrors(event.headers);
+		if (sessionIdError) {
+			logger.error({ message: sessionIdError, messageCode: MessageCodes.INVALID_SESSION_ID });
+			throw new AppError(sessionIdError, HttpCodesEnum.UNAUTHORIZED);
+		}
+
+		return {
+			sessionId: event.headers[Constants.X_SESSION_ID]!,
+			encodedHeader: event.headers[Constants.ENCODED_AUDIT_HEADER] ?? "",
+		};
 	}
 }
 

--- a/src/AbortHandler.ts
+++ b/src/AbortHandler.ts
@@ -5,7 +5,7 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { MessageCodes } from "./models/enums/MessageCodes";
 import { Constants } from "./utils/Constants";
 import { HttpCodesEnum } from "./utils/HttpCodesEnum";
-import { Response, unauthorizedResponse } from "./utils/Response";
+import { Response } from "./utils/Response";
 import { AppError } from "./utils/AppError";
 import { AbortRequestProcessor } from "./services/AbortRequestProcessor";
 import { getSessionIdHeaderErrors } from "./utils/Validations";

--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -49,7 +49,7 @@ export class AbortRequestProcessor {
   	return AbortRequestProcessor.instance;
   }
 
-  async processRequest(sessionId: string): Promise<Response> {
+  async processRequest(sessionId: string, encodedHeader: string): Promise<Response> {
   	const cicSessionInfo = await this.cicService.getSessionById(sessionId);
   	this.logger.appendKeys({
   		govuk_signin_journey_id: cicSessionInfo?.clientSessionId,
@@ -89,7 +89,7 @@ export class AbortRequestProcessor {
   		await this.cicService.sendToTXMA(this.txmaQueueUrl, {
   			event_name: TxmaEventNames.CIC_CRI_SESSION_ABORTED,
   			...buildCoreEventFields(cicSessionInfo, this.issuer, cicSessionInfo.clientIpAddress),
-  		});
+  		}, encodedHeader);
   	} catch (error) {
   		this.logger.error("Auth session successfully aborted. Failed to send CIC_CRI_SESSION_ABORTED event to TXMA", {
   			error,

--- a/src/services/CicService.ts
+++ b/src/services/CicService.ts
@@ -203,7 +203,13 @@ export class CicService {
 		}
 	}
 
-	async sendToTXMA(QueueUrl: string, event: TxmaEvent): Promise<void> {
+	async sendToTXMA(QueueUrl: string, event: TxmaEvent, encodedHeader?: string): Promise<void> {
+		
+		if (encodedHeader) {
+			event.restricted = event.restricted ?? { device_information: { encoded: "" } };
+			event.restricted.device_information = { encoded: encodedHeader };
+		}
+
 		const messageBody = JSON.stringify(event);
 		const params = {
 			MessageBody: messageBody,

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -76,8 +76,8 @@ export class SessionRequestProcessor {
 		let encodedHeader, clientIpAddress;
 
 		if (event.headers) {
-		encodedHeader = event.headers[Constants.ENCODED_AUDIT_HEADER] ?? "";
-		clientIpAddress = event.headers[Constants.X_FORWARDED_FOR] ?? event.requestContext.identity?.sourceIp;
+			encodedHeader = event.headers[Constants.ENCODED_AUDIT_HEADER] ?? "";
+			clientIpAddress = event.headers[Constants.X_FORWARDED_FOR] ?? event.requestContext.identity?.sourceIp;
 		} else {
 			clientIpAddress = event.requestContext.identity?.sourceIp;
 		}

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -54,7 +54,8 @@ export async function stubStartPost(journeyType: string): Promise<any> {
 export async function sessionPost(clientId?: string, request?: string): Promise<any> {
 	const path = "/session";
 	try {
-		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request });
+		// const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request });
+		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request }, { headers: { "txma-audit-encoded": "encoded-header", "x-forwarded-for": "user ip address" } });
 		return postRequest;
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
@@ -212,7 +213,7 @@ export async function getSessionAndVerifyKey(sessionId: string, tableName: strin
 export async function abortPost(sessionId: string): Promise<AxiosResponse<string>> {
 	const path = "/abort";
 	try {
-		return await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId } });
+		return await API_INSTANCE.post(path, null, { headers: { "x-govuk-signin-session-id": sessionId, "txma-audit-encoded": "encoded-header" } });
 	} catch (error: any) {
 		console.log(`Error response from ${path} endpoint: ${error}`);
 		return error.response;

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -54,7 +54,6 @@ export async function stubStartPost(journeyType: string): Promise<any> {
 export async function sessionPost(clientId?: string, request?: string): Promise<any> {
 	const path = "/session";
 	try {
-		// const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request });
 		const postRequest = await API_INSTANCE.post(path, { client_id: clientId, request }, { headers: { "txma-audit-encoded": "encoded-header", "x-forwarded-for": "user ip address" } });
 		return postRequest;
 	} catch (error: any) {

--- a/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
@@ -39,6 +39,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [

--- a/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
@@ -58,6 +58,25 @@
             "required": [
                 "evidence"
             ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [

--- a/src/tests/data/CIC_CRI_START_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_SCHEMA.json
@@ -39,6 +39,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [

--- a/src/tests/unit/AbortHandler.test.ts
+++ b/src/tests/unit/AbortHandler.test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { mock } from "jest-mock-extended";
+import { lambdaHandler, logger } from "../../AbortHandler";
+import { AbortRequestProcessor } from "../../services/AbortRequestProcessor";
+import { VALID_REQUEST, INVALID_SESSION_ID, MISSING_SESSION_ID } from "./data/abort-events";
+import { Constants } from "../../utils/Constants";
+import { MessageCodes } from "../../models/enums/MessageCodes";
+
+const mockAbortRequestProcessor = mock<AbortRequestProcessor>();
+
+describe("AbortHandler", () => {
+	let loggerSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		loggerSpy = jest.spyOn(logger, "error");
+	});
+
+	it("return Unauthorized when x-govuk-signin-session-id header is missing", async () => {
+		const message = `Missing header: ${Constants.X_SESSION_ID} is required`;
+		AbortRequestProcessor.getInstance = jest.fn().mockReturnValue(mockAbortRequestProcessor);
+		const response = await lambdaHandler(MISSING_SESSION_ID, "");
+
+		expect(response).toEqual({
+			statusCode: 401,
+			body: message,
+		});
+		expect(loggerSpy).toHaveBeenCalledWith({ message, messageCode: MessageCodes.INVALID_SESSION_ID });
+	});
+
+	it("return Unauthorized when x-govuk-signin-session-id header is invalid", async () => {
+		const message = `${Constants.X_SESSION_ID} header does not contain a valid uuid`;
+		AbortRequestProcessor.getInstance = jest.fn().mockReturnValue(mockAbortRequestProcessor);
+
+		const response = await lambdaHandler(INVALID_SESSION_ID, "");
+		expect(response).toEqual({
+			statusCode: 401,
+			body: message,
+		});
+		expect(loggerSpy).toHaveBeenCalledWith({ message, messageCode: MessageCodes.INVALID_SESSION_ID });
+	});
+
+	it("return success for valid request", async () => {
+		AbortRequestProcessor.getInstance = jest.fn().mockReturnValue(mockAbortRequestProcessor);
+
+		await lambdaHandler(VALID_REQUEST, "");
+		expect(mockAbortRequestProcessor.processRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/tests/unit/data/abort-events.ts
+++ b/src/tests/unit/data/abort-events.ts
@@ -1,0 +1,74 @@
+export const VALID_REQUEST = {
+	httpMethod: "POST",
+	body: JSON.stringify({ "reason": "session_expired" }),
+	headers: {
+		// pragma: allowlist secret
+		"x-govuk-signin-session-id": "e4c0b0d8-a4a4-4c3b-91e2-44e743fcdbf9",
+	},
+	isBase64Encoded: false,
+	multiValueHeaders: {},
+	multiValueQueryStringParameters: {},
+	path: "/abort",
+	pathParameters: {},
+	queryStringParameters: {},
+	requestContext: {
+		accountId: "",
+		apiId: "",
+		authorizer: {},
+		httpMethod: "post",
+		identity: {
+			accessKey: "",
+			accountId: "",
+			apiKey: "",
+			apiKeyId: "",
+			caller: "",
+			clientCert: {
+				clientCertPem: "",
+				issuerDN: "",
+				serialNumber: "",
+				subjectDN: "",
+				validity: { notAfter: "", notBefore: "" },
+			},
+			cognitoAuthenticationProvider: "",
+			cognitoAuthenticationType: "",
+			cognitoIdentityId: "",
+			cognitoIdentityPoolId: "",
+			principalOrgId: "",
+			sourceIp: "",
+			user: "",
+			userAgent: "",
+			userArn: "",
+		},
+		path: "/abort",
+		protocol: "HTTP/1.1",
+		requestId: "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+		requestTimeEpoch: 1428582896000,
+		resourceId: "123456",
+		resourcePath: "/abort",
+		stage: "dev",
+	},
+	resource: "/abort",
+	stageVariables: {},
+};
+
+export const UNSUPPORTED_METHOD = {
+	...VALID_REQUEST,
+	httpMethod: "GET",
+};
+
+export const INVALID_SESSION_ID = {
+	...VALID_REQUEST,
+	headers: {
+		"x-govuk-signin-session-id": "SomeInvalidSessionID",
+	},
+};
+
+export const MISSING_SESSION_ID = {
+	...VALID_REQUEST,
+	headers: {},
+};
+
+export const RESOURCE_NOT_FOUND = {
+	...VALID_REQUEST,
+	resource: "/invalid",
+};

--- a/src/tests/unit/data/session-events.ts
+++ b/src/tests/unit/data/session-events.ts
@@ -1,7 +1,7 @@
 export const VALID_SESSION = {
 	httpMethod: "POST",
 	body: '{"request":"eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0.aGaU_dmUdqW-DeYL9YbWg1PzNUWYtBKH2KYxrz6i_5hKrl33VU_i4qJ7Xbq6KTK4oKTSPddEX-Uw3rCgOSuKIWPmlXxT1o8a1t-KpKRj2R7NV2WyS3bkynQM1TwgLOimold6a9-HbrMFCvbKpkTuKWBYKSy3hZSU9nLpFq0JsAXqDlvmg8xb9DHS_-DDuCYNgLw7s7VKIEd8NvCFRvGd29GvTlkNhSIED39sU5oEuWIKo-7cbczv8CQom5r4QF1LfEfOD_nCu3sABA6pMMG3tvLbVkB8k4biFTZYSGOw549kVWRT1jUrlErbzik-0nsVhVV6rti2oB6zW4Xut0lSgw.L7yhXweQrHDQ4c34.oP3IbCknq-ASWlqAreQtyv6__usTCEaF41ZC5iqYZRhGVMKbJp0gGTw9vG00kkGNFO3fPjbFTnIwL9AZDUrB2MIREhTUp0TWSyAL7PGgTevLNQA1xk_Wr54RKwrpafp-Do75MEwrVgafxUExYqUBG2OQkBnxnzeN0iFptDPvmE7tsKX8O_dCsrbteYIqWEASdJIWJ2pdiJ94TBq3hHRERskgLavOF3VjkA79WBjvJLbNl3RXO80DMzggEasFjvxW6n5Ky7xtg2rig7ajhUi8kJpfaoZMthNd0tIBEQ8Q-IAaMwdCtNKvGhEPB4W7LYlr0sZ0UIUwIPNGBSfUh9iXDFLCWDgp9mR3CQ5x700s6HlD14ybbGN0z5XVenmcdmZFL_qzMVSp7F5X0rI2yiRN6ZL3kHahi5MfsGP7yeGzcQNO7boVNyP3aoo8ly6wo7-5YthadCDC6KaAac4k7FCmUj9ufuXhgEVNWSbdozlR_j3VVSoPxlJNv6D4LIj_C-jN_f_YMpObrwpdmsm0anaByaPymALCuMvpbu6GmRsq55xIt3RrctwddXYPiq39rIIgtUh2-aYTIeQA4HVsedz-U8MPi-HClrYdSe32a23aBeCcjKEGzaGyjASXyDfK2QEiAcnGiqWiJM8xXHIw7vEJ0D0b_G8fUr87z7zpQMmZ97eQ2P_a7pH-7Pr1SKMlvqG58BVdxpHl6IlqpOEJENNoQxFO47jWF05LwwEgppvr_Rc7DsA4_U39My2vX4f5QxFulSycs5lSWYp3bw-f39TRg0yKTpSwXpxEJFg85WM-lh5U9rKGXhPNWVo76DSfR4tWcdPPLkbijqI-DIAQ7v0osV3kSIlNgpumRq8RkLaqvynCJDJyrCY4rwbOPH3MfmHQXP5l4RT_OdmOz-gg3if9X_767e4cu0mrkRwk-y9GJpnhWI8xpOAq6UIeQuYHh85RPKpQHv2IBFx3mmYTjUryxJiMuY0m-v6bYffduF6fV8GwVEYqhJIb45B_JyUbhymIlmmIiBBh0c-6n0DAxwtyhA1tSzLWWpjtSSJTLYkuNwradSwDzFfUAu5ni0v0T3jvvyjq1Cf9xEoiaXbH6UpoDE55_2NLfYegsjiVqrFufu-FPMiZI-uTq8H2HvbcnnQHZxx8ZVsqLeEC05BLD02vycytxYkCAXuZNDhEdq4C_Q2fWQTg5h4wxBwIeINmBbAcO5RdaVB8mmBTk3MvWygFVDXgxoEkA_4mhf65Y0hMKF4VJtLaYUHdrlL22TVY7DLBrbSQVPhq4MQOsyvmtSsSk-eRbnkQikD3gUI6IanKwEsO3Qf4Zk0aIuN6Eu6oh_bKytQTjN2hkE4by8ZfkK0FZC1JJLwiLn7nnaRvAIUrVYFLLBnVbkEuL6RdAbzl_p3Ow7tbS_vdVutRV7HMnK08LOSJZBxpSSiIiQ4oQEBLY1-07vIUbvXvnxNG8nk.vW5aUxd1nYceNoELcApISg","client_id":"ipv-core-stub"}',
-	headers: { "X-Forwarded-For": "192.0.2.1" },
+	headers: { "x-forwarded-for": "1.1.1", "txma-audit-encoded": "ABCDEFG" },
 	isBase64Encoded: false,
 	multiValueHeaders: {},
 	multiValueQueryStringParameters: {},
@@ -31,7 +31,7 @@ export const VALID_SESSION = {
 			cognitoIdentityId: "",
 			cognitoIdentityPoolId: "",
 			principalOrgId: "",
-			sourceIp: "",
+			sourceIp: "2.2.2",
 			user: "",
 			userAgent: "",
 			userArn: "",

--- a/src/tests/unit/services/SessionRequestProcessor.test.ts
+++ b/src/tests/unit/services/SessionRequestProcessor.test.ts
@@ -292,7 +292,7 @@ describe("SessionRequestProcessor", () => {
 					transaction_id: "",
 					user_id: "",
 				},
-			},"ABCDEFG");
+			}, "ABCDEFG");
 		});
 
 		it("ip_address is source IP if no X_FORWARDED_FOR header is present", async () => {
@@ -306,7 +306,7 @@ describe("SessionRequestProcessor", () => {
 			const fakeTime = 1684933200;
 			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
 
-			const job = await sessionRequestProcessor.processRequest({ ...VALID_SESSION, headers: { "txma-audit-encoded": "ABCDEFG"  } });
+			const job = await sessionRequestProcessor.processRequest({ ...VALID_SESSION, headers: { "txma-audit-encoded": "ABCDEFG" } });
 			console.log("job", job);
 			expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
 				event_name: "CIC_CRI_START",
@@ -321,7 +321,7 @@ describe("SessionRequestProcessor", () => {
 					transaction_id: "",
 					user_id: "",
 				},
-			},"ABCDEFG");
+			}, "ABCDEFG");
 		});
 
 		it("correctly sends context field when it is provided in JWT", async () => {
@@ -355,7 +355,7 @@ describe("SessionRequestProcessor", () => {
 						context: "bank_account",
 					},
 				},
-			},"ABCDEFG");
+			}, "ABCDEFG");
 		});
 	});
 

--- a/src/tests/unit/services/SessionRequestProcessor.test.ts
+++ b/src/tests/unit/services/SessionRequestProcessor.test.ts
@@ -13,6 +13,7 @@ import { JWTPayload } from "jose";
 import { Jwt } from "../../../utils/IVeriCredential";
 import { ValidationHelper } from "../../../utils/ValidationHelper";
 import { ISessionItem } from "../../../models/ISessionItem";
+import { Constants } from "../../../utils/Constants";
 
 let sessionRequestProcessor: SessionRequestProcessor;
 const mockCicService = mock<CicService>();
@@ -264,66 +265,97 @@ describe("SessionRequestProcessor", () => {
 		});
 	});
 
-	it("should send correct TXMA event", async () => {
-		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
-		mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
-		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
-		mockValidationHelper.isJwtValid.mockReturnValue("");
-		mockCicService.getSessionById.mockResolvedValue(undefined);
-		mockCicService.createAuthSession.mockResolvedValue();
-		jest.useFakeTimers();
-		const fakeTime = 1684933200;
-		jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
+	describe("should send correct TXMA event", () => {
+		it("ip_address is X_FORWARDED_FOR if header is present", async () => {
+			mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
+			mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
+			mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
+			mockValidationHelper.isJwtValid.mockReturnValue("");
+			mockCicService.getSessionById.mockResolvedValue(undefined);
+			mockCicService.createAuthSession.mockResolvedValue();
+			jest.useFakeTimers();
+			const fakeTime = 1684933200;
+			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
 
-		await sessionRequestProcessor.processRequest(VALID_SESSION);
+			await sessionRequestProcessor.processRequest(VALID_SESSION);
 
-		expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
-			event_name: "CIC_CRI_START",
-			component_id: "https://XXX-c.env.account.gov.uk",
-			timestamp: 1684933200,
-			event_timestamp_ms: 1684933200000,
-			user: {
-				govuk_signin_journey_id: "abcdef",
-				ip_address: "",
-				persistent_session_id: undefined,
-				session_id: "sessionId",
-				transaction_id: "",
-				user_id: "",
-			},
-		});
-	});
-
-	it("should send correct TXMA event where context is provided in JWT", async () => {
-		mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
-		mockKmsJwtAdapter.decode.mockReturnValue({ ...decodedJwtFactory(), payload: { ...decodedJwtFactory().payload, context: "bank_account" } });
-		mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
-		mockValidationHelper.isJwtValid.mockReturnValue("");
-		mockCicService.getSessionById.mockResolvedValue(undefined);
-		mockCicService.createAuthSession.mockResolvedValue();
-		jest.useFakeTimers();
-		const fakeTime = 1684933200;
-		jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
-
-		await sessionRequestProcessor.processRequest(VALID_SESSION);
-
-		expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
-			event_name: "CIC_CRI_START",
-			component_id: "https://XXX-c.env.account.gov.uk",
-			timestamp: 1684933200,
-			event_timestamp_ms: 1684933200000,
-			user: {
-				govuk_signin_journey_id: "abcdef",
-				ip_address: "",
-				persistent_session_id: undefined,
-				session_id: "sessionId",
-				transaction_id: "",
-				user_id: "",
-			},
-			extensions: {
-				evidence: {
-					context: "bank_account",
+			expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
+				event_name: "CIC_CRI_START",
+				component_id: "https://XXX-c.env.account.gov.uk",
+				timestamp: 1684933200,
+				event_timestamp_ms: 1684933200000,
+				user: {
+					govuk_signin_journey_id: "abcdef",
+					ip_address: "1.1.1",
+					persistent_session_id: undefined,
+					session_id: "sessionId",
+					transaction_id: "",
+					user_id: "",
 				},
-			},
+			},"ABCDEFG");
+		});
+
+		it("ip_address is source IP if no X_FORWARDED_FOR header is present", async () => {
+			mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
+			mockKmsJwtAdapter.decode.mockReturnValue(decodedJwtFactory());
+			mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
+			mockValidationHelper.isJwtValid.mockReturnValue("");
+			mockCicService.getSessionById.mockResolvedValue(undefined);
+			mockCicService.createAuthSession.mockResolvedValue();
+			jest.useFakeTimers();
+			const fakeTime = 1684933200;
+			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
+
+			const job = await sessionRequestProcessor.processRequest({ ...VALID_SESSION, headers: { "txma-audit-encoded": "ABCDEFG"  } });
+			console.log("job", job);
+			expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
+				event_name: "CIC_CRI_START",
+				component_id: "https://XXX-c.env.account.gov.uk",
+				timestamp: 1684933200,
+				event_timestamp_ms: 1684933200000,
+				user: {
+					govuk_signin_journey_id: "abcdef",
+					ip_address: "2.2.2",
+					persistent_session_id: undefined,
+					session_id: "sessionId",
+					transaction_id: "",
+					user_id: "",
+				},
+			},"ABCDEFG");
+		});
+
+		it("correctly sends context field when it is provided in JWT", async () => {
+			mockKmsJwtAdapter.decrypt.mockResolvedValue("success");
+			mockKmsJwtAdapter.decode.mockReturnValue({ ...decodedJwtFactory(), payload: { ...decodedJwtFactory().payload, context: "bank_account" } });
+			mockKmsJwtAdapter.verifyWithJwks.mockResolvedValue(decryptedJwtPayloadFactory());
+			mockValidationHelper.isJwtValid.mockReturnValue("");
+			mockCicService.getSessionById.mockResolvedValue(undefined);
+			mockCicService.createAuthSession.mockResolvedValue();
+			jest.useFakeTimers();
+			const fakeTime = 1684933200;
+			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.000Z
+
+			await sessionRequestProcessor.processRequest(VALID_SESSION);
+
+			expect(mockCicService.sendToTXMA).toHaveBeenCalledWith("MYQUEUE", {
+				event_name: "CIC_CRI_START",
+				component_id: "https://XXX-c.env.account.gov.uk",
+				timestamp: 1684933200,
+				event_timestamp_ms: 1684933200000,
+				user: {
+					govuk_signin_journey_id: "abcdef",
+					ip_address: "1.1.1",
+					persistent_session_id: undefined,
+					session_id: "sessionId",
+					transaction_id: "",
+					user_id: "",
+				},
+				extensions: {
+					evidence: {
+						context: "bank_account",
+					},
+				},
+			},"ABCDEFG");
 		});
 	});
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -63,6 +63,10 @@ export class Constants {
     static readonly NO_PHOTO_ID_JOURNEY = "NO_PHOTO_ID";
 
     static readonly EXPECTED_CONTEXT = "bank_account";
+
+	static readonly X_FORWARDED_FOR = "x-forwarded-for";
+
+	static readonly ENCODED_AUDIT_HEADER = "txma-audit-encoded";
     
 }
 

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -1,9 +1,6 @@
 export interface CredentialSubject {
 	name?: object[];
 	birthDate?: object[];
-	device_information?: {
-		encoded: string;
-	};
 }
 
 export interface VerifiedCredential {
@@ -12,8 +9,7 @@ export interface VerifiedCredential {
 	credentialSubject: CredentialSubject;
 }
 
-export interface TxMACredentialSubject {
-	credentialSubject: CredentialSubject;
+export interface TxMACredentialSubject extends CredentialSubject {
 	device_information?: {
 		encoded: string;
 	};
@@ -24,6 +20,7 @@ export interface TxMAVerifiedCredential {
 	type: string[];
 	credentialSubject: TxMACredentialSubject;
 }
+
 // limit to supported algs https://datatracker.ietf.org/doc/html/rfc7518
 export type Algorithm =
     "HS256" | "HS384" | "HS512" |

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -1,6 +1,9 @@
 export interface CredentialSubject {
-	name: object[];
-	birthDate: object[];
+	name?: object[];
+	birthDate?: object[];
+	device_information?: {
+		encoded: string;
+	};
 }
 export interface VerifiedCredential {
 	"@context": string[];

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -5,10 +5,24 @@ export interface CredentialSubject {
 		encoded: string;
 	};
 }
+
 export interface VerifiedCredential {
 	"@context": string[];
 	type: string[];
 	credentialSubject: CredentialSubject;
+}
+
+export interface TxMACredentialSubject {
+	credentialSubject: CredentialSubject;
+	device_information?: {
+		encoded: string;
+	};
+}
+
+export interface TxMAVerifiedCredential {
+	"@context": string[];
+	type: string[];
+	credentialSubject: TxMACredentialSubject;
 }
 // limit to supported algs https://datatracker.ietf.org/doc/html/rfc7518
 export type Algorithm =

--- a/src/utils/IVeriCredential.ts
+++ b/src/utils/IVeriCredential.ts
@@ -9,18 +9,6 @@ export interface VerifiedCredential {
 	credentialSubject: CredentialSubject;
 }
 
-export interface TxMACredentialSubject extends CredentialSubject {
-	device_information?: {
-		encoded: string;
-	};
-}
-
-export interface TxMAVerifiedCredential {
-	"@context": string[];
-	type: string[];
-	credentialSubject: TxMACredentialSubject;
-}
-
 // limit to supported algs https://datatracker.ietf.org/doc/html/rfc7518
 export type Algorithm =
     "HS256" | "HS384" | "HS512" |

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -1,4 +1,4 @@
-import { VerifiedCredential } from "./IVeriCredential";
+import { TxMACredentialSubject } from "./IVeriCredential";
 import { ISessionItem } from "../models/ISessionItem";
 
 export type TxmaEventName =
@@ -34,7 +34,7 @@ export interface BaseTxmaEvent {
 
 export interface TxmaEvent extends BaseTxmaEvent {
 	"event_name": TxmaEventName;
-	"restricted"?: VerifiedCredential["credentialSubject"];
+	"restricted"?: TxMACredentialSubject["credentialSubject"];
 	"extensions"?: Extensions;
 }
 

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -1,4 +1,4 @@
-import { TxMACredentialSubject } from "./IVeriCredential";
+import { TxMAVerifiedCredential } from "./IVeriCredential";
 import { ISessionItem } from "../models/ISessionItem";
 
 export type TxmaEventName =
@@ -34,7 +34,7 @@ export interface BaseTxmaEvent {
 
 export interface TxmaEvent extends BaseTxmaEvent {
 	"event_name": TxmaEventName;
-	"restricted"?: TxMACredentialSubject["credentialSubject"];
+	"restricted"?: TxMAVerifiedCredential["credentialSubject"];
 	"extensions"?: Extensions;
 }
 

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -1,4 +1,4 @@
-import { TxMAVerifiedCredential } from "./IVeriCredential";
+import { CredentialSubject } from "./IVeriCredential";
 import { ISessionItem } from "../models/ISessionItem";
 
 export type TxmaEventName =
@@ -23,6 +23,18 @@ export interface Evidence {
 
 export interface Extensions {
 	"evidence": Evidence;
+}
+
+export interface TxMACredentialSubject extends CredentialSubject {
+	device_information?: {
+		encoded: string;
+	};
+}
+
+export interface TxMAVerifiedCredential {
+	"@context": string[];
+	type: string[];
+	credentialSubject: TxMACredentialSubject;
 }
 
 export interface BaseTxmaEvent {

--- a/src/utils/Validations.ts
+++ b/src/utils/Validations.ts
@@ -1,0 +1,13 @@
+import { APIGatewayProxyEventHeaders } from "aws-lambda";
+import { Constants } from "./Constants";
+
+export const getSessionIdHeaderErrors = (headers: APIGatewayProxyEventHeaders): string | void => {
+	const sessionId = headers[Constants.X_SESSION_ID];
+	if (!sessionId) {
+		return `Missing header: ${Constants.X_SESSION_ID} is required`;
+	}
+
+	if (!Constants.REGEX_UUID.test(sessionId)) {
+		return `${Constants.X_SESSION_ID} header does not contain a valid uuid`;
+	}
+};


### PR DESCRIPTION
### What changed

- Add AuditHeader to /session API spec
- Add AuditHeader to /abort API spec
- Include the encoded header in the restricted.device_information.encoded field of TxMA events emitted by the corresponding lambdas:
- CIC_CRI_START
- CIC_CRI_SESSION_ABORTED
- Update logic first attempt getting the sourceIp from the X-Forwarded-For header, and only revert to checking the event.requestContext.identity?.sourceIp if not present

### Why did it change

Required for CloudFront initiative

### Issue tracking

- [KIWI-1780](https://govukverify.atlassian.net/browse/KIWI-1780)

### Evidence

API tests passing
![Screenshot 2024-04-29 at 11 13 22](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/f90d7da3-a98c-443d-939f-1e1dfcaa239a)

/session endpoint with headers:
![Screenshot 2024-04-29 at 11 37 36](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/c7fd1801-ca8a-4cd5-be84-6d76d66e33b0)
![Screenshot 2024-04-29 at 11 38 42](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/d98a41ed-8b69-4d27-9e5d-85c72650b934)
![Screenshot 2024-04-29 at 11 40 47](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/5a847d7f-1dcd-45a9-9379-0fc55096fe70)

/abort endpoint with headers
![Screenshot 2024-04-29 at 11 48 05](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/78559ac7-6b8a-46bc-99a8-41b2bd7562e2)
![Screenshot 2024-04-29 at 11 47 52](https://github.com/govuk-one-login/ipv-cri-cic-api/assets/118540036/4e818988-24a4-4bca-bd43-6631caf74476)




[KIWI-1780]: https://govukverify.atlassian.net/browse/KIWI-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ