### PR TITLE
Update JSON Schema for TxMA events impacted by KIWI-1780

### DIFF
--- a/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_SESSION_ABORTED_SCHEMA.json
@@ -39,6 +39,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [

--- a/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
@@ -58,6 +58,25 @@
             "required": [
                 "evidence"
             ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [

--- a/src/tests/data/CIC_CRI_START_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_SCHEMA.json
@@ -39,6 +39,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

QA changes to validate the following AC

Include the encoded header in the restricted.device_information.encoded field of TxMA events emitted by the corresponding lambdas:

- CIC_CRI_START
- CIC_CRI_SESSION_ABORTED

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1780](https://govukverify.atlassian.net/browse/KIWI-1780)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1780]: https://govukverify.atlassian.net/browse/KIWI-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ