### PR TITLE
[KIWI-1940] - CIC | BE | Handle new Core flag for Low Confidence Journeys

### DIFF
--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -154,6 +154,7 @@ export class SessionRequestProcessor {
 			return unauthorizedResponse;
 		}
 
+
 		const JwtErrors = this.validationHelper.isJwtValid(
 			jwtPayload, requestBodyClientId, configClient.redirectUri);
 
@@ -179,6 +180,19 @@ export class SessionRequestProcessor {
 			return GenericServerError;
 		}
 
+		let journeyContext;
+		
+		switch (jwtPayload.context) {
+			case Constants.CONTEXT_BANK_ACCOUNT:
+				journeyContext = Constants.NO_PHOTO_ID_JOURNEY;
+				break;
+			case Constants.CONTEXT_LOW_CONFIDENCE:
+				journeyContext = Constants.LOW_CONFIDENCE_JOURNEY;
+				break;
+			default:
+				journeyContext = Constants.FACE_TO_FACE_JOURNEY;
+		}
+
 		const session: ISessionItem = {
 			sessionId,
 			clientId: jwtPayload.client_id,
@@ -192,10 +206,7 @@ export class SessionRequestProcessor {
 			clientIpAddress,
 			attemptCount: 0,
 			authSessionState: "CIC_SESSION_CREATED",
-			journey: jwtPayload.context === Constants.CONTEXT_BANK_ACCOUNT ? Constants.NO_PHOTO_ID_JOURNEY 
-				: (jwtPayload.context === Constants.CONTEXT_LOW_CONFIDENCE 
-					? Constants.LOW_CONFIDENCE_JOURNEY 
-					: Constants.FACE_TO_FACE_JOURNEY),
+			journey: journeyContext,
 		};
 
 		try {

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -154,14 +154,11 @@ export class SessionRequestProcessor {
 			return unauthorizedResponse;
 		}
 
-		const JwtErrorsBankAccount = this.validationHelper.isJwtValid(
-			jwtPayload, requestBodyClientId, configClient.redirectUri, Constants.CONTEXT_BANK_ACCOUNT);
-			
-		const JwtErrorsLowConfidence = this.validationHelper.isJwtValid(
-			jwtPayload, requestBodyClientId, configClient.redirectUri, Constants.CONTEXT_LOW_CONFIDENCE);
-			
-		if (JwtErrorsBankAccount.length > 0 && JwtErrorsLowConfidence.length > 0) {
-			this.logger.error(JwtErrorsBankAccount, {
+		const JwtErrors = this.validationHelper.isJwtValid(
+			jwtPayload, requestBodyClientId, configClient.redirectUri);
+
+		if (JwtErrors.length > 0) {
+			this.logger.error(JwtErrors, {
 				messageCode: MessageCodes.FAILED_VALIDATING_JWT,
 			});
 			return unauthorizedResponse;		

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -154,7 +154,6 @@ export class SessionRequestProcessor {
 			return unauthorizedResponse;
 		}
 
-		// NEEDS REFACTORING
 		const JwtErrorsBankAccount = this.validationHelper.isJwtValid(
 			jwtPayload, requestBodyClientId, configClient.redirectUri, Constants.CONTEXT_BANK_ACCOUNT);
 			

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -39,6 +39,9 @@ export async function stubStartPost(journeyType: string): Promise<any> {
 		case "NO_PHOTO_ID":
 			postRequest = await axios.post(`${path}`, { context: "bank_account" });
 			break;
+		case "LOW_CONFIDENCE":
+			postRequest = await axios.post(`${path}`, { context: "hmrc_check" });
+			break;
 		case "INVALID":
 			postRequest = await axios.post(`${path}`, { context: "INVALID" });
 			break;

--- a/src/tests/api/ApiUtils.ts
+++ b/src/tests/api/ApiUtils.ts
@@ -4,6 +4,7 @@ import { HARNESS_API_INSTANCE } from "./ApiTestSteps";
 import { TxmaEvent, TxmaEventName } from "../../utils/TxmaEvent";
 import * as CIC_CRI_START_SCHEMA from "../data/CIC_CRI_START_SCHEMA.json";
 import * as CIC_CRI_START_BANK_ACCOUNT_SCHEMA from "../data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json";
+import * as CIC_CRI_START_LOW_CONFIDENCE_SCHEMA from "../data/CIC_CRI_START_LOW_CONFIDENCE_SCHEMA.json";
 import * as CIC_CRI_AUTH_CODE_ISSUED_SCHEMA from "../data/CIC_CRI_AUTH_CODE_ISSUED_SCHEMA.json";
 import * as CIC_CRI_END_SCHEMA from "../data/CIC_CRI_END_SCHEMA.json";
 import * as CIC_CRI_VC_ISSUED_SCHEMA from "../data/CIC_CRI_VC_ISSUED_SCHEMA.json";
@@ -11,6 +12,7 @@ import * as CIC_CRI_SESSION_ABORTED_SCHEMA from "../data/CIC_CRI_SESSION_ABORTED
 
 const ajv = new Ajv({ strictTuples: false });
 ajv.addSchema(CIC_CRI_START_SCHEMA, "CIC_CRI_START_SCHEMA");
+ajv.addSchema(CIC_CRI_START_LOW_CONFIDENCE_SCHEMA, "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA");
 ajv.addSchema(CIC_CRI_START_BANK_ACCOUNT_SCHEMA, "CIC_CRI_START_BANK_ACCOUNT_SCHEMA");
 ajv.addSchema(CIC_CRI_AUTH_CODE_ISSUED_SCHEMA, "CIC_CRI_AUTH_CODE_ISSUED_SCHEMA");
 ajv.addSchema(CIC_CRI_END_SCHEMA, "CIC_CRI_END_SCHEMA");

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -11,6 +11,7 @@ describe("Happy path tests", () => {
 		it.each([
 			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
 			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("For $journeyType journey type", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -26,6 +27,7 @@ describe("Happy path tests", () => {
 		it.each([
 			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
 			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -40,6 +42,7 @@ describe("Happy path tests", () => {
 		it.each([
 			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
 			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -59,6 +62,7 @@ describe("Happy path tests", () => {
 		it.each([
 			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
 			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -75,6 +79,7 @@ describe("Happy path tests", () => {
 		it.each([
 			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
 			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 

--- a/src/tests/data/CIC_CRI_START_LOW_CONFIDENCE_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_LOW_CONFIDENCE_SCHEMA.json
@@ -1,0 +1,91 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "transaction_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "transaction_id",
+                "session_id",
+                "govuk_signin_journey_id",
+                "ip_address"
+            ]
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "event_timestamp_ms": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "object",
+                    "properties": {
+                        "context": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "context"
+                    ]
+                }
+            },
+            "required": [
+                "evidence"
+            ]
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "timestamp",
+        "event_timestamp_ms",
+        "component_id",
+        "extensions",
+        "restricted"
+    ]
+}

--- a/src/tests/data/happyPathKenneth.json
+++ b/src/tests/data/happyPathKenneth.json
@@ -1,0 +1,6 @@
+{
+    "firstName": "Kenneth",
+    "lastName": "Decerqueira",
+    "dateOfBirth": "1970-03-26",
+    "journeyType": "LOW_CONFIDENCE"
+}

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -62,7 +62,11 @@ export class Constants {
 
     static readonly NO_PHOTO_ID_JOURNEY = "NO_PHOTO_ID";
 
-    static readonly EXPECTED_CONTEXT = "bank_account";
+    static readonly LOW_CONFIDENCE_JOURNEY = "LOW_CONFIDENCE";
+
+    static readonly CONTEXT_BANK_ACCOUNT = "bank_account";
+
+    static readonly CONTEXT_LOW_CONFIDENCE = "hmrc_check";
 
 	static readonly X_FORWARDED_FOR = "x-forwarded-for";
 

--- a/src/utils/ValidationHelper.ts
+++ b/src/utils/ValidationHelper.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { validateOrReject } from "class-validator";
 import { AppError } from "./AppError";
 import { Logger } from "@aws-lambda-powertools/logger";

--- a/src/utils/ValidationHelper.ts
+++ b/src/utils/ValidationHelper.ts
@@ -80,7 +80,7 @@ export class ValidationHelper {
 	};
 
 	isJwtValid = (jwtPayload: JwtPayload,
-		requestBodyClientId: string, expectedRedirectUri: string, expectedContext: string): string => {
+		requestBodyClientId: string, expectedRedirectUri: string): string => {
 
 		if (!this.isJwtComplete(jwtPayload)) {
 			return "JWT validation/verification failed: Missing mandatory fields in JWT payload";
@@ -94,10 +94,9 @@ export class ValidationHelper {
 			return `JWT validation/verification failed: Unable to retrieve redirect URI for client_id: ${requestBodyClientId}`;
 		} else if (expectedRedirectUri !== jwtPayload.redirect_uri) {
 			return `JWT validation/verification failed: Redirect uri ${jwtPayload.redirect_uri} does not match configuration uri ${expectedRedirectUri}`;
-		} else if (jwtPayload.context != null && expectedContext !== jwtPayload.context) {
-			return `JWT validation/verification failed: Context ${jwtPayload.context} does not match configuration context ${expectedContext}`;
+		} else if (jwtPayload.context != null && jwtPayload.context !== Constants.CONTEXT_BANK_ACCOUNT && jwtPayload.context !== Constants.CONTEXT_LOW_CONFIDENCE) {
+			return `JWT validation/verification failed: Context ${jwtPayload.context} does not match configuration context ${Constants.CONTEXT_BANK_ACCOUNT} or ${Constants.CONTEXT_LOW_CONFIDENCE}`;
 		}
-
 		return "";
 	};
 }


### PR DESCRIPTION
### What changed

Added functionality to accept "hmrc_check" context property in call from IPV, save this as "LOW_CONFIDENCE" in the journey property in Dynamo DB session table and return in session-config call

### Why did it change

To route users on the front end to the low confidence journey

### Issue tracking

- [KIWI-1940](https://govukverify.atlassian.net/browse/KIWI-1940)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

![Screenshot 2024-08-05 at 15 21 06](https://github.com/user-attachments/assets/4bcc9eb1-342d-49cf-a6f4-67ac55d522b2)

![Screenshot 2024-08-05 at 15 21 32](https://github.com/user-attachments/assets/351f1011-ea5d-4b77-9760-c76223f58551)

![Screenshot 2024-08-05 at 15 22 48](https://github.com/user-attachments/assets/659725e2-480d-4604-a2be-d4528d2d88e1)

![Screenshot 2024-08-05 at 15 24 56](https://github.com/user-attachments/assets/0555983a-f2ca-45e1-b923-ab9751ecab1b)





[KIWI-1940]: https://govukverify.atlassian.net/browse/KIWI-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ