### PR TITLE
Update /session to include new context flags for journey type

### DIFF
--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -36,10 +36,10 @@ export async function stubStartPost(journeyType: string): Promise<any> {
 
 	let postRequest: AxiosResponse;
 	switch (journeyType) {
-		case "NO_PHOTO_ID":
+		case "bank_account":
 			postRequest = await axios.post(`${path}`, { context: "bank_account" });
 			break;
-		case "LOW_CONFIDENCE":
+		case "hmrc_check":
 			postRequest = await axios.post(`${path}`, { context: "hmrc_check" });
 			break;
 		case "INVALID":

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -9,9 +9,9 @@ import { getTxmaEventsFromTestHarness, validateTxMAEventData } from "./ApiUtils"
 describe("Happy path tests", () => {
 	describe("/session endpoint", () => {
 		it.each([
-			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
-			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
-			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
+			{ journeyType: "f2f", schemaName: "CIC_CRI_START_SCHEMA" },
+			{ journeyType: "bank_account", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "hmrc_check", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("For $journeyType journey type", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -25,9 +25,9 @@ describe("Happy path tests", () => {
 
 	describe("/claimedIdentity endpoint", () => {
 		it.each([
-			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
-			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
-			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
+			{ journeyType: "f2f", schemaName: "CIC_CRI_START_SCHEMA" },
+			{ journeyType: "bank_account", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "hmrc_check", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -40,9 +40,9 @@ describe("Happy path tests", () => {
 
 	describe("/authorization endpoint", () => {
 		it.each([
-			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
-			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
-			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
+			{ journeyType: "f2f", schemaName: "CIC_CRI_START_SCHEMA" },
+			{ journeyType: "bank_account", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "hmrc_check", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -60,9 +60,9 @@ describe("Happy path tests", () => {
 
 	describe("/token endpoint", () => {
 		it.each([
-			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
-			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
-			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
+			{ journeyType: "f2f", schemaName: "CIC_CRI_START_SCHEMA" },
+			{ journeyType: "bank_account", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "hmrc_check", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 
@@ -77,9 +77,9 @@ describe("Happy path tests", () => {
 
 	describe("/userinfo endpoint", () => {
 		it.each([
-			{ journeyType: "FACE_TO_FACE", schemaName: "CIC_CRI_START_SCHEMA" },
-			{ journeyType: "NO_PHOTO_ID", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
-			{ journeyType: "LOW_CONFIDENCE", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
+			{ journeyType: "f2f", schemaName: "CIC_CRI_START_SCHEMA" },
+			{ journeyType: "bank_account", schemaName: "CIC_CRI_START_BANK_ACCOUNT_SCHEMA" },
+			{ journeyType: "hmrc_check", schemaName: "CIC_CRI_START_LOW_CONFIDENCE_SCHEMA" },
 		])("Successful Request Tests - $journeyType", async ({ journeyType, schemaName }: { journeyType: string; schemaName: string }) => {
 			const sessionId = await startStubServiceAndReturnSessionId(journeyType);
 

--- a/src/tests/api/e2eNegativePath.test.ts
+++ b/src/tests/api/e2eNegativePath.test.ts
@@ -10,7 +10,7 @@ import dataSpaceEnd from "../data/dataSpaceEnd.json";
 describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 	let stubResponse: any;
 	beforeAll(async () => {
-		stubResponse = await stubStartPost("FACE_TO_FACE");
+		stubResponse = await stubStartPost("f2f");
 	});
 
 	it("E2E Negative Path Journey - Sessions: Empty Request Body", async () => {
@@ -47,7 +47,7 @@ describe("/session Unhappy Path", () => {
 describe("E2E Negative Path Tests - Claimed Identity Endpoint", () => {
 	let sessionId: any;
 	beforeAll(async () => {
-		sessionId = await startStubServiceAndReturnSessionId("FACE_TO_FACE");
+		sessionId = await startStubServiceAndReturnSessionId("f2f");
 	});
 
 	it("E2E Negative Path Journey - Claimed Identity: No Name in Payload", async () => {
@@ -73,7 +73,7 @@ describe("Claimed Identity Negative Path Tests", () => {
 		[dataSpaceStart],
 		[dataSpaceEnd],
 	])("E2E Happy Path Journey - User Info", async (userData: any) => {
-		const stubResponse = await stubStartPost("FACE_TO_FACE");
+		const stubResponse = await stubStartPost("f2f");
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 
 		expect(sessionResponse.status).toBe(200);

--- a/src/tests/contract/data/session-items.json
+++ b/src/tests/contract/data/session-items.json
@@ -37,7 +37,7 @@
                     "N": "4865226539"
                   },
                   "journey": {
-                    "S": "FACE_TO_FACE"
+                    "S": "f2f"
                   },
                   "redirectUri": {
                     "S": "https://identity.staging.account.gov.uk/credential-issuer/callback?id=claimedIdentity"
@@ -85,7 +85,7 @@
                   "N": "4865226539"
                 },
                 "journey": {
-                  "S": "FACE_TO_FACE"
+                  "S": "f2f"
                 },
                 "redirectUri": {
                   "S": "https://ipvstub.review-c.dev.account.gov.uk/redirect"

--- a/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_BANK_ACCOUNT_SCHEMA.json
@@ -44,14 +44,19 @@
             "type": "object",
             "properties": {
                 "evidence": {
-                    "type": "object",
-                    "properties": {
-                        "context": {
-                            "type": "string"
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "context": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "context"
+                            ]
                         }
-                    },
-                    "required": [
-                        "context"
                     ]
                 }
             },
@@ -85,7 +90,8 @@
         "timestamp",
         "event_timestamp_ms",
         "component_id",
-        "extensions"
+        "extensions",
+        "restricted"
     ],
     "additionalProperties": false
 }

--- a/src/tests/data/CIC_CRI_START_LOW_CONFIDENCE_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_LOW_CONFIDENCE_SCHEMA.json
@@ -44,14 +44,19 @@
             "type": "object",
             "properties": {
                 "evidence": {
-                    "type": "object",
-                    "properties": {
-                        "context": {
-                            "type": "string"
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "context": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "context"
+                            ]
                         }
-                    },
-                    "required": [
-                        "context"
                     ]
                 }
             },
@@ -87,5 +92,6 @@
         "component_id",
         "extensions",
         "restricted"
-    ]
+    ],
+    "additionalProperties": false
 }

--- a/src/tests/data/CIC_CRI_START_SCHEMA.json
+++ b/src/tests/data/CIC_CRI_START_SCHEMA.json
@@ -40,6 +40,30 @@
         "component_id": {
             "type": "string"
         },
+        "extensions": {
+            "type": "object",
+            "properties": {
+                "evidence": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "context": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "context"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "evidence"
+            ]
+        },
         "restricted": {
             "type": "object",
             "properties": {
@@ -65,7 +89,9 @@
         "user",
         "timestamp",
         "event_timestamp_ms",
-        "component_id"
+        "component_id",
+        "extensions",
+        "restricted"
     ],
     "additionalProperties": false
 }

--- a/src/tests/data/happyPathBillyJoe.json
+++ b/src/tests/data/happyPathBillyJoe.json
@@ -2,5 +2,5 @@
     "firstName": "Billy-Joe",
     "lastName": "Test.User",
     "dateOfBirth": "1970-03-26",
-    "journeyType": "NO_PHOTO_ID"
+    "journeyType": "bank_account"
 }

--- a/src/tests/data/happyPathBjörn.json
+++ b/src/tests/data/happyPathBjörn.json
@@ -2,5 +2,5 @@
     "firstName": "Bjorn",
     "lastName": "Test-User",
     "dateOfBirth": "1970-03-26",
-    "journeyType": "FACE_TO_FACE"
+    "journeyType": "f2f"
 }

--- a/src/tests/data/happyPathKenneth.json
+++ b/src/tests/data/happyPathKenneth.json
@@ -2,5 +2,5 @@
     "firstName": "Kenneth",
     "lastName": "Decerqueira",
     "dateOfBirth": "1970-03-26",
-    "journeyType": "LOW_CONFIDENCE"
+    "journeyType": "hmrc_check"
 }

--- a/src/tests/data/happyPathManuel.json
+++ b/src/tests/data/happyPathManuel.json
@@ -2,5 +2,5 @@
     "firstName": "Manuel",
     "lastName": "Test'User",
     "dateOfBirth": "1970-03-26",
-    "journeyType": "NO_PHOTO_ID"
+    "journeyType": "bank_account"
 }

--- a/src/tests/data/happyPathSlim.json
+++ b/src/tests/data/happyPathSlim.json
@@ -2,5 +2,5 @@
     "firstName": "Slim",
     "lastName": "Test User",
     "dateOfBirth": "1970-03-26",
-    "journeyType": "FACE_TO_FACE"
+    "journeyType": "f2f"
 }

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -56,7 +56,7 @@ export class Constants {
 
     static readonly GIVEN_NAME_REGEX = /^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$/;
 
-	static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id"];
+	  static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id"];
 
     static readonly FACE_TO_FACE_JOURNEY = "f2f";
 
@@ -64,9 +64,9 @@ export class Constants {
 
     static readonly LOW_CONFIDENCE_JOURNEY = "hmrc_check";
 
-	static readonly X_FORWARDED_FOR = "x-forwarded-for";
+	  static readonly X_FORWARDED_FOR = "x-forwarded-for";
 
-	static readonly ENCODED_AUDIT_HEADER = "txma-audit-encoded";
+	  static readonly ENCODED_AUDIT_HEADER = "txma-audit-encoded";
     
 }
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -58,15 +58,11 @@ export class Constants {
 
 	static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id"];
 
-    static readonly FACE_TO_FACE_JOURNEY = "FACE_TO_FACE";
+    static readonly FACE_TO_FACE_JOURNEY = "f2f";
 
-    static readonly NO_PHOTO_ID_JOURNEY = "NO_PHOTO_ID";
+    static readonly NO_PHOTO_ID_JOURNEY = "bank_account";
 
-    static readonly LOW_CONFIDENCE_JOURNEY = "LOW_CONFIDENCE";
-
-    static readonly CONTEXT_BANK_ACCOUNT = "bank_account";
-
-    static readonly CONTEXT_LOW_CONFIDENCE = "hmrc_check";
+    static readonly LOW_CONFIDENCE_JOURNEY = "hmrc_check";
 
 	static readonly X_FORWARDED_FOR = "x-forwarded-for";
 

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -22,7 +22,7 @@ export interface Evidence {
 }
 
 export interface Extensions {
-	"evidence": Evidence;
+	"evidence": [Evidence];
 }
 
 export interface TxMACredentialSubject extends CredentialSubject {

--- a/src/utils/ValidationHelper.ts
+++ b/src/utils/ValidationHelper.ts
@@ -94,8 +94,8 @@ export class ValidationHelper {
 			return `JWT validation/verification failed: Unable to retrieve redirect URI for client_id: ${requestBodyClientId}`;
 		} else if (expectedRedirectUri !== jwtPayload.redirect_uri) {
 			return `JWT validation/verification failed: Redirect uri ${jwtPayload.redirect_uri} does not match configuration uri ${expectedRedirectUri}`;
-		} else if (jwtPayload.context != null && jwtPayload.context !== Constants.CONTEXT_BANK_ACCOUNT && jwtPayload.context !== Constants.CONTEXT_LOW_CONFIDENCE) {
-			return `JWT validation/verification failed: Context ${jwtPayload.context} does not match configuration context ${Constants.CONTEXT_BANK_ACCOUNT} or ${Constants.CONTEXT_LOW_CONFIDENCE}`;
+		} else if (jwtPayload.context != null && jwtPayload.context !== Constants.NO_PHOTO_ID_JOURNEY && jwtPayload.context !== Constants.LOW_CONFIDENCE_JOURNEY) {
+			return `JWT validation/verification failed: Context ${jwtPayload.context} does not match configuration context ${Constants.NO_PHOTO_ID_JOURNEY} or ${Constants.LOW_CONFIDENCE_JOURNEY}`;
 		}
 		return "";
 	};


### PR DESCRIPTION
### What changed

Updated `/session` logic to directly store the value for the journey context provided in the initial request from core into the `session-table`. Additionally, fixed the structure of the TxMA event emitted for `CIC_CRI_START` and included the 'f2f' context value for default journeys (i.e. no value for journey context in initial request)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1963](https://govukverify.atlassian.net/browse/KIWI-1963)

### Evidence

With `hmrc_check` flag
![1](https://github.com/user-attachments/assets/f01f577b-a202-49e2-a089-c2e16d425ac5)
![2](https://github.com/user-attachments/assets/aa866434-bcef-4734-836f-1b0b4f0baa62)
![3](https://github.com/user-attachments/assets/c7444aa7-79c2-42a0-a0d1-dfbc5499c298)

Without context flag in initial request - defaults to `f2f`
![4](https://github.com/user-attachments/assets/de8037f1-8dba-4336-8d90-1b940fc406bd)
![5](https://github.com/user-attachments/assets/41313678-1fc8-422c-8ad0-2595f4791f44)
![6](https://github.com/user-attachments/assets/07c9b1bc-7e94-4ac0-8339-d85e1265462a)

[KIWI-1963]: https://govukverify.atlassian.net/browse/KIWI-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ