### PR TITLE
[KIWI-1987] Add max length validation to name fields within the API Spec

### DIFF
--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -1000,19 +1000,19 @@ components:
           example: Frederick Joseph
           pattern: ^[A-Za-z .'-]*$
           minLength: 2
-          maxLength: 50
+          maxLength: 40
           description: claimed given legal name
         family_names:
           type: string
           pattern: ^[A-Za-z .'-]*$
           example: Flintstone
           minLength: 2
-          maxLength: 50
+          maxLength: 40
           description: claimed family legal name
         date_of_birth:
           type: string
           format: date
-          pattern: ^\d{4}-\d{2}-\d{2}$
+          maxLength: 18
           example: "1970-01-01"
           description: claimed Date of Birth
     JWKSFile:

--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -998,11 +998,13 @@ components:
         given_names:
           type: string
           example: Frederick Joseph
-          pattern: ^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$
+          pattern: /^[A-Za-z .'-]*$/
+          minLength: 2
           description: claimed given legal name
         family_names:
           type: string
-          pattern: ^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$
+          pattern: /^[A-Za-z .'-]*$/
+          minLength: 2
           example: Flintstone
           description: claimed family legal name
         date_of_birth:

--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -998,18 +998,21 @@ components:
         given_names:
           type: string
           example: Frederick Joseph
-          pattern: /^[A-Za-z .'-]*$/
+          pattern: ^[A-Za-z .'-]*$
           minLength: 2
+          maxLength: 50
           description: claimed given legal name
         family_names:
           type: string
-          pattern: /^[A-Za-z .'-]*$/
-          minLength: 2
+          pattern: ^[A-Za-z .'-]*$
           example: Flintstone
+          minLength: 2
+          maxLength: 50
           description: claimed family legal name
         date_of_birth:
           type: string
           format: date
+          pattern: ^\d{4}-\d{2}-\d{2}$
           example: "1970-01-01"
           description: claimed Date of Birth
     JWKSFile:


### PR DESCRIPTION
- Added `maxlength` validation to the Name fields in the CIC, restricting the length to 40 characters to prevent excessively large payloads. The maximum possible payload is now capped at 98 characters.

- Implemented special character validation for the Name fields in the CIC API spec, ensuring consistent validation across both frontend and backend.

- Matched the regular expression pattern for name validation from the frontend to the backend, aligning validation rules.

- Added a `minLength` validation of 2 characters for properties of type `string`, ensuring all Name fields comply with frontend validation rules.

- Added `maxLength` validation of `18` to the DOB.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->
- [BAV-API-1987](https://github.com/govuk-one-login/ipv-cri-bav-api/pull/253)

## Evidence 


https://github.com/user-attachments/assets/8ecbec4f-4a05-4135-a456-bb29d78e2b5e


https://github.com/user-attachments/assets/e62d17ed-9460-4292-a6e9-43e00d299f8b


https://github.com/user-attachments/assets/85e558ed-6a75-42bb-9d65-a86c3b6eb414


https://github.com/user-attachments/assets/e60e9b95-cfd0-4352-b782-4c00d8126911







