### PR TITLE
Updating SonarCube GH Action to avoid deprecation

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test and coverage
         run: npm run test:unit -- --coverage
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@52a9e8e35980e6bcaf24d88180a61501e6f2605b
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
         with:
           coverage-location: src/coverage/
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Run SonarCloud scan
-          uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
+          uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
           with:
             coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
             github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed changes
Bumped the GH Action to use the new SonarCloud GH Action

### What changed
version pin

### Why did it change
Upstream action deprecated

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1428