### PR TITLE
[KIWI-2115] - Write unit tests for all methods of the JwtUtils class

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -252,7 +252,16 @@
         "is_verified": false,
         "line_number": 31
       }
+    ],
+    "src/tests/unit/utils/JwtUtils.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/tests/unit/utils/JwtUtils.test.ts",
+        "hashed_secret": "7c3b0120b54432616849fdb3472a29f472cc142a",
+        "is_verified": false,
+        "line_number": 48
+      }
     ]
   },
-  "generated_at": "2024-02-26T16:32:20Z"
+  "generated_at": "2025-03-17T08:25:30Z"
 }

--- a/src/tests/unit/utils/JwtUtils.test.ts
+++ b/src/tests/unit/utils/JwtUtils.test.ts
@@ -1,0 +1,51 @@
+import { jwtUtils } from "../../../utils/JwtUtils";
+
+describe("jwtUtils", () => {
+	it("should base64 encode a string", () => {
+		const input = "This is a test string";
+		const expectedOutput = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		expect(jwtUtils.base64Encode(input)).toBe(expectedOutput);
+	});
+
+	it("should base64 decode a string to Uint8Array", () => {
+		const input = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		const expectedOutput = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		expect(jwtUtils.base64DecodeToUint8Array(input)).toEqual(
+			expectedOutput,
+		);
+	});
+
+	it("should base64 decode a string to string", () => {
+		const input = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		const expectedOutput = "This is a test string";
+		expect(jwtUtils.base64DecodeToString(input)).toBe(expectedOutput);
+	});
+
+	it("should decode a Uint8Array to string", () => {
+		const input = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		const expectedOutput = "This is a test string";
+		expect(jwtUtils.decode(input)).toBe(expectedOutput);
+	});
+
+	it("should encode a string to Uint8Array", () => {
+		const input = "This is a test string";
+		const expectedOutput = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		expect(jwtUtils.encode(input)).toEqual(expectedOutput);
+	});
+
+	it("should return the correct hashed kid", () => {
+		const keyId = "test-key-id";
+		const expectedHashedKid =
+      "b4bc4f795761b7695032158cc06aeb67a46b6ddc7d2121db9509d06b4d2d13e1";
+		expect(jwtUtils.getHashedKid(keyId)).toBe(expectedHashedKid);
+	});
+});


### PR DESCRIPTION
### What changed

Adds unit tests for JwtUtils module

### Why did it change

To increase code coverage and dependability of service

### Issue tracking

- [KIWI-2115](https://govukverify.atlassian.net/browse/KIWI-2115)

### Evidence

![image](https://github.com/user-attachments/assets/d875fe86-1c27-4e4c-8209-87777fe10e37)



[KIWI-2115]: https://govukverify.atlassian.net/browse/KIWI-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ