### PR TITLE
KIWI-2219 - OAuth | Add second key to IPV Core Stub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": "cic-ipv-stub/src/tests/jsonWebKeys.test.ts",
         "hashed_secret": "e69cb67e72e1a1f4699b3de9d5085f820a0c7172",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 13
       }
     ],
     "cic-ipv-stub/src/tests/startCicCheck.test.ts": [
@@ -263,5 +263,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-17T08:25:30Z"
+  "generated_at": "2025-03-24T08:44:44Z"
 }

--- a/cic-ipv-stub/src/handlers/jsonWebKeys.ts
+++ b/cic-ipv-stub/src/handlers/jsonWebKeys.ts
@@ -5,13 +5,21 @@ import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 
 export const handler = async (): Promise<APIGatewayProxyResult> => {
-  const { signingKey } = getConfig();
+  const { signingKey, additionalKey } = getConfig();
   const jwks: Jwks = {
     keys: [],
   };
   if (signingKey != null) {
     const signingKeyId = signingKey.split("/").pop() ?? "";
     const formattedKey = await getAsJwk(signingKeyId);
+    if (formattedKey != null) {
+      jwks.keys.push(formattedKey);
+    }
+  }
+
+  if (additionalKey != null) {
+    const additionalKeyId = additionalKey.split("/").pop() ?? "";
+    const formattedKey = await getAsJwk(additionalKeyId);
     if (formattedKey != null) {
       jwks.keys.push(formattedKey);
     }
@@ -31,8 +39,8 @@ const v3KmsClient = new KMSClient({
   maxAttempts: 2,
 });
 
-function getConfig(): { signingKey: string | null } {
-  return { signingKey: process.env.SIGNING_KEY ?? null };
+function getConfig(): { signingKey: string | null , additionalKey: string | null} {
+  return { signingKey: process.env.SIGNING_KEY ?? null, additionalKey: process.env.ADDITIONAL_KEY ?? null };
 }
 
 const getAsJwk = async (keyId: string): Promise<JsonWebKey | null> => {

--- a/cic-ipv-stub/src/tests/jsonWebKeys.test.ts
+++ b/cic-ipv-stub/src/tests/jsonWebKeys.test.ts
@@ -28,6 +28,6 @@ describe("JWKS Endpoint", () => {
     const jwks = JSON.parse(response.body);
     expect(jwks.keys).toBeDefined();
     expect(jwks.keys.length >= 2).toBe(true);
-    expect(jwks.keys.find((k) => k.use === "sig")).toBeDefined();
+    expect(jwks.keys.find((k: any) => k.use === "sig")).toBeDefined();
   });
 });

--- a/cic-ipv-stub/src/tests/jsonWebKeys.test.ts
+++ b/cic-ipv-stub/src/tests/jsonWebKeys.test.ts
@@ -5,6 +5,7 @@ import { mockClient } from "aws-sdk-client-mock";
 describe("JWKS Endpoint", () => {
   beforeEach(() => {
     process.env.SIGNING_KEY = "test";
+    process.env.ADDITIONAL_KEY = "test2";
     const mockKmsClient = mockClient(KMSClient);
     mockKmsClient.on(GetPublicKeyCommand).resolves({
       KeyId: "test",
@@ -19,14 +20,14 @@ describe("JWKS Endpoint", () => {
     });
   });
 
-  it("provides at least one signing key", async () => {
+  it("provides at least two signing keys", async () => {
     const response = await handler();
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeDefined();
 
     const jwks = JSON.parse(response.body);
     expect(jwks.keys).toBeDefined();
-    expect(jwks.keys.length >= 1).toBe(true);
+    expect(jwks.keys.length >= 2).toBe(true);
     expect(jwks.keys.find((k) => k.use === "sig")).toBeDefined();
   });
 });

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -110,6 +110,7 @@ Resources:
                   - kms:GetPublicKey
                 Resource:
                   - !GetAtt IPVStubKMSSigningKey.Arn
+                  - !GetAtt IPVStubKMSAdditionalKey.Arn
               - Effect: Allow
                 Action:
                   - "logs:CreateLogGroup"
@@ -395,6 +396,7 @@ Resources:
       Environment:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
+          ADDITIONAL_KEY: !Ref IPVStubKMSAdditionalKey
       Policies:
         - Statement:
             - Sid: KMSSignPolicy
@@ -403,6 +405,7 @@ Resources:
                 - kms:GetPublicKey
               Resource:
                 - !GetAtt IPVStubKMSSigningKey.Arn
+                - !GetAtt IPVStubKMSAdditionalKey.Arn
       Role: !GetAtt IPVStubLambdaRole.Arn
       PermissionsBoundary: !If
         - UsePermissionsBoundary
@@ -466,6 +469,32 @@ Resources:
     Type: AWS::KMS::Key
     Properties:
       Description: A KMS Key for testing signing KMS integration in the development account.
+      Enabled: true
+      EnableKeyRotation: false
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "kms:*"
+            Resource:
+              - "*"
+      KeySpec: ECC_NIST_P256
+      KeyUsage: SIGN_VERIFY
+      MultiRegion: false
+      PendingWindowInDays: 7
+      Tags:
+        - Key: KeyType
+          Value: Test Signing Key
+        - Key: Environment
+          Value: !Sub ${Environment}
+          
+  IPVStubKMSAdditionalKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: A additional valid signing key in KMS to reflect multiple JWK's returned by the 'well-known' endpoint
       Enabled: true
       EnableKeyRotation: false
       KeyPolicy:


### PR DESCRIPTION
### What changed

Added additional JWK to IPV stub 'well-known' endpoint  response - this is a different, valid key with a different `kid` to the one currently used

### Why did it change

To remain aligned with the IPV core service

### Issue tracking

- [KIWI-2219](https://govukverify.atlassian.net/browse/KIWI-2219)

### Evidence
![Screenshot 2025-03-24 at 08 19 44](https://github.com/user-attachments/assets/11476503-7c72-4a79-8f45-d7b25ef663df)

![Screenshot 2025-03-24 at 08 20 12](https://github.com/user-attachments/assets/0ea90db5-85b2-41de-9732-fde04701487f)

[KIWI-2219]: https://govukverify.atlassian.net/browse/KIWI-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ