### PR TITLE
KIWI-2193 - OAuth | BE | Implement Lambda Caching for Core Signing Keys

### DIFF
--- a/cic-ipv-stub/src/handlers/jsonWebKeys.ts
+++ b/cic-ipv-stub/src/handlers/jsonWebKeys.ts
@@ -29,6 +29,9 @@ export const handler = async (): Promise<APIGatewayProxyResult> => {
   }
   return {
     statusCode: 200,
+    headers: {
+      "cache-control": "max-age=300"
+    },
     body: JSON.stringify(jwks),
   };
 };

--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,7 +2,7 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "cic-cri-api"
+stack_name = "cic-cri-api-2193b"
 s3_prefix = "cic-cri-api"
 region = "eu-west-2"
 confirm_changeset = false


### PR DESCRIPTION
### What changed

Added functionality for `/session` lambda to cache response from IPV Core public JWKS endpoint to prevent unnecessary calls. Cache time is extracted from header in payload response, or defaults to 5 mins. 

### Issue tracking

- [KIWI-2193](https://govukverify.atlassian.net/browse/KIWI-2193)

![Screenshot 2025-04-04 at 09 01 23](https://github.com/user-attachments/assets/f4f132b4-0ae5-4246-8cd1-04312ce26eac)


[KIWI-2193]: https://govukverify.atlassian.net/browse/KIWI-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ