### PR TITLE
Key Rotation: Update logic to test for missingKid

### DIFF
--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -181,7 +181,7 @@ export class SessionRequestProcessor {
 			return GenericServerError;
 		}
 
-		const journeyContext = jwtPayload.context ? jwtPayload.context : Constants.FACE_TO_FACE_JOURNEY;
+		const journeyContext = jwtPayload.context ?? Constants.FACE_TO_FACE_JOURNEY;
 
 		const session: ISessionItem = {
 			sessionId,
@@ -191,7 +191,7 @@ export class SessionRequestProcessor {
 			expiryDate: (Date.now() / 1000) + +this.authSessionTtlInSecs,
 			createdDate: Date.now() / 1000,
 			state: jwtPayload.state,
-			subject: jwtPayload.sub ? jwtPayload.sub : "",
+			subject: jwtPayload.sub ?? "",
 			persistentSessionId: jwtPayload.persistent_session_id, // Might not be used
 			clientIpAddress,
 			attemptCount: 0,

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -33,30 +33,31 @@ export async function startStubServiceAndReturnSessionId(journeyType: string): P
 
 interface StubPayload {
 	context?: string;
-	invalidKid?: string;
-	missingKid?: string;
+	[key: string]: any;
 }
 
-export async function stubStartPost(journeyType: string, invalidKid?: boolean, missingKid?: boolean): Promise<any> {
-	const path = constants.DEV_IPV_STUB_URL;
-	let payload: StubPayload = {};
-  
+interface KidOptions {
+	kidType?: 'invalidKid' | 'missingKid';
+	value?: boolean;
+}
+
+export async function stubStartPost(journeyType: string, options?: KidOptions): Promise<AxiosResponse<any>> {
+	const path = constants.DEV_IPV_STUB_URL!;
+
+	const payload: StubPayload = {};
+
 	if (journeyType !== 'f2f') {
-	  payload.context = journeyType;
+		payload.context = journeyType;
 	}
-  
-	if (invalidKid) {
-	  payload.invalidKid = "true";
+
+	if (options && options.kidType) {
+		payload[options.kidType] = options.value ?? false;
 	}
-  
-	if (missingKid) {
-	  payload.missingKid = "true";
-	}  
-  
-	const postRequest: AxiosResponse = await axios.post(`${path}`, payload);
+
+	const postRequest: AxiosResponse<any> = await axios.post(path, payload);
 	expect(postRequest.status).toBe(201);
 	return postRequest;
-  }
+}
 
 export async function sessionPost(clientId?: string, request?: string): Promise<any> {
 	const path = "/session";

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -36,19 +36,16 @@ interface JourneyOptions {
 	value: boolean;
 }
 interface StubPayload {
-	context?: string;
+	context: string;
 	journeyOptions?: JourneyOptions;
 }
 
 export async function stubStartPost(context: string, options?: JourneyOptions): Promise<AxiosResponse<any>> {
 	const path = constants.DEV_IPV_STUB_URL!;
 
-	const payload: StubPayload = {};
-
-	// If no context is provided CIC CRI will default to "f2f"
-	if (context) {
-		payload.context = context;
-	}
+	const payload: StubPayload = {
+		context
+	};
 
 	if (options) {
 		payload.journeyOptions = options

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -34,12 +34,13 @@ export async function startStubServiceAndReturnSessionId(journeyType: string): P
 interface StubPayload {
 	context?: string;
 	invalidKid?: string;
+	missingKid?: string;
 }
 
-export async function stubStartPost(journeyType: string, invalidKid?: boolean): Promise<any> {
+export async function stubStartPost(journeyType: string, invalidKid?: boolean, missingKid?: boolean): Promise<any> {
 	const path = constants.DEV_IPV_STUB_URL;
-  
 	let payload: StubPayload = {};
+  
 	if (journeyType !== 'f2f') {
 	  payload.context = journeyType;
 	}
@@ -47,6 +48,10 @@ export async function stubStartPost(journeyType: string, invalidKid?: boolean): 
 	if (invalidKid) {
 	  payload.invalidKid = "true";
 	}
+  
+	if (missingKid) {
+	  payload.missingKid = "true";
+	}  
   
 	const postRequest: AxiosResponse = await axios.post(`${path}`, payload);
 	expect(postRequest.status).toBe(201);

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -32,8 +32,7 @@ export async function startStubServiceAndReturnSessionId(journeyType: string): P
 }
 
 interface JourneyOptions {
-	journeyType: 'invalidKid' | 'missingKid';
-	value: boolean;
+	journeyOptions: 'invalidKid' | 'missingKid';
 }
 interface StubPayload {
 	context?: string;
@@ -52,7 +51,7 @@ export async function stubStartPost(context: string, options?: JourneyOptions): 
 	}
 
 	if (options) {
-		payload[options.journeyType] = true;
+		payload[options.journeyOptions] = true;
 	}
 
 	const postRequest: AxiosResponse<any> = await axios.post(path, payload);

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -36,19 +36,23 @@ interface JourneyOptions {
 	value: boolean;
 }
 interface StubPayload {
-	context: string;
-	journeyOptions?: JourneyOptions;
+	context?: string;
+	invalidKid?: boolean;
+	missingKid?: boolean;
 }
 
 export async function stubStartPost(context: string, options?: JourneyOptions): Promise<AxiosResponse<any>> {
 	const path = constants.DEV_IPV_STUB_URL!;
 
-	const payload: StubPayload = {
-		context
-	};
+	const payload: StubPayload = {};
+
+	// Core do not pass "f2f" as a context, if context is omitted CIC CRI will default to "f2f"
+	if (context !== 'f2f') {
+		payload.context = context;
+	}
 
 	if (options) {
-		payload.journeyOptions = options
+		payload[options.journeyType] = true;
 	}
 
 	const postRequest: AxiosResponse<any> = await axios.post(path, payload);

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -31,27 +31,29 @@ export async function startStubServiceAndReturnSessionId(journeyType: string): P
 	return sessionResponse.data.session_id;
 }
 
+interface JourneyOptions {
+	journeyType: 'invalidKid' | 'missingKid';
+	value: boolean;
+}
 interface StubPayload {
-	context?: string;
-	[key: string]: any;
+	context: string;
+	journeyOptions?: JourneyOptions;
 }
 
-interface KidOptions {
-	kidType?: 'invalidKid' | 'missingKid';
-	value?: boolean;
-}
-
-export async function stubStartPost(journeyType: string, options?: KidOptions): Promise<AxiosResponse<any>> {
+export async function stubStartPost(context: string, options?: JourneyOptions): Promise<AxiosResponse<any>> {
 	const path = constants.DEV_IPV_STUB_URL!;
 
-	const payload: StubPayload = {};
+	const payload: StubPayload = {
+		context
+	};
 
-	if (journeyType !== 'f2f') {
-		payload.context = journeyType;
+	// I'm in favour of removing this but if we leave it in we should explain why
+	if (context !== 'f2f') {
+		payload.context = context;
 	}
 
-	if (options && options.kidType) {
-		payload[options.kidType] = options.value ?? false;
+	if (options) {
+		payload.journeyOptions = options
 	}
 
 	const postRequest: AxiosResponse<any> = await axios.post(path, payload);

--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -36,19 +36,17 @@ interface JourneyOptions {
 	value: boolean;
 }
 interface StubPayload {
-	context: string;
+	context?: string;
 	journeyOptions?: JourneyOptions;
 }
 
 export async function stubStartPost(context: string, options?: JourneyOptions): Promise<AxiosResponse<any>> {
 	const path = constants.DEV_IPV_STUB_URL!;
 
-	const payload: StubPayload = {
-		context
-	};
+	const payload: StubPayload = {};
 
-	// I'm in favour of removing this but if we leave it in we should explain why
-	if (context !== 'f2f') {
+	// If no context is provided CIC CRI will default to "f2f"
+	if (context) {
 		payload.context = context;
 	}
 

--- a/src/tests/api/e2eNegativePath.test.ts
+++ b/src/tests/api/e2eNegativePath.test.ts
@@ -39,7 +39,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Invalid kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, true, false);
+		const stubResponse = await stubStartPost(journeyType, { kidType: 'invalidKid', value: true });
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 
@@ -50,7 +50,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Missing kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, false, true);
+		const stubResponse = await stubStartPost(journeyType, { kidType: 'missingKid', value: true });
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 

--- a/src/tests/api/e2eNegativePath.test.ts
+++ b/src/tests/api/e2eNegativePath.test.ts
@@ -39,7 +39,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Invalid kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, { journeyType: 'invalidKid', value: true });
+		const stubResponse = await stubStartPost(journeyType, { journeyOptions: 'invalidKid'});
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 
@@ -50,7 +50,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Missing kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, { journeyType: 'missingKid', value: true });
+		const stubResponse = await stubStartPost(journeyType, { journeyOptions: 'missingKid'});
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 

--- a/src/tests/api/e2eNegativePath.test.ts
+++ b/src/tests/api/e2eNegativePath.test.ts
@@ -38,10 +38,22 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "f2f" },
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
-	])("JWT signature not verified using Core's signing key", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, true);
+	])("JWT signature not verified using Core's signing key - Invalid kid", async ({ journeyType }: { journeyType: string }) => {
+		const stubResponse = await stubStartPost(journeyType, true, false);
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
+		expect(sessionResponse.data.message).toBe('Unauthorized'); 
+	});
+
+	it.each([
+		{ journeyType: "f2f" },
+		{ journeyType: "bank_account" },
+		{ journeyType: "hmrc_check" },
+	])("JWT signature not verified using Core's signing key - Missing kid", async ({ journeyType }: { journeyType: string }) => {
+		const stubResponse = await stubStartPost(journeyType, false, true);
+		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+		expect(sessionResponse.status).toBe(401);
+		expect(sessionResponse.data.message).toBe('Unauthorized'); 
 	});
 
 });

--- a/src/tests/api/e2eNegativePath.test.ts
+++ b/src/tests/api/e2eNegativePath.test.ts
@@ -39,7 +39,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Invalid kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, { kidType: 'invalidKid', value: true });
+		const stubResponse = await stubStartPost(journeyType, { journeyType: 'invalidKid', value: true });
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 
@@ -50,7 +50,7 @@ describe("E2E Negative Path Tests - Sessions Endpoint", () => {
 		{ journeyType: "bank_account" },
 		{ journeyType: "hmrc_check" },
 	])("JWT signature not verified using Core's signing key - Missing kid", async ({ journeyType }: { journeyType: string }) => {
-		const stubResponse = await stubStartPost(journeyType, { kidType: 'missingKid', value: true });
+		const stubResponse = await stubStartPost(journeyType, { journeyType: 'missingKid', value: true });
 		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
 		expect(sessionResponse.status).toBe(401);
 		expect(sessionResponse.data.message).toBe('Unauthorized'); 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -56,7 +56,7 @@ export class Constants {
 
     static readonly GIVEN_NAME_REGEX = /^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$/;
 
-	  static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id"];
+    static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "session_id", "govuk_signin_journey_id"];
 
     static readonly FACE_TO_FACE_JOURNEY = "f2f";
 
@@ -64,9 +64,9 @@ export class Constants {
 
     static readonly LOW_CONFIDENCE_JOURNEY = "hmrc_check";
 
-	  static readonly X_FORWARDED_FOR = "x-forwarded-for";
+    static readonly X_FORWARDED_FOR = "x-forwarded-for";
 
-	  static readonly ENCODED_AUDIT_HEADER = "txma-audit-encoded";
+    static readonly ENCODED_AUDIT_HEADER = "txma-audit-encoded";
     
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1f5f4ed4-d1fe-473c-9c46-7b4949c7060c)

## Proposed changes

### What changed

BackEnd changes allow us to test for missingKid scenario by adding a new key to the start Stub payload (missingKid = true) 
Tests added to validate we're able to return a 401 status code and Unauthorised error message when hitting the session endpoint with a JWT with a missingKid.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
