### PR TITLE
[KIWI-2306] - CIC | OAuth | Move public encryption keys to new S3

### DIFF
--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -575,7 +575,7 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/${JsonWebKeysBucket}/.well-known/jwks.json"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-cic-published-keys-${Environment}/.well-known/jwks.json"
         responses:
           default:
             statusCode: "200"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -502,6 +502,9 @@ Resources:
             Principal:
               Service: apigateway.amazonaws.com
         Version: 2012-10-17
+      Tags:
+        - Key: key_consumer_type
+        - Value: manage
       Policies:
         - PolicyName: AccessJWKSjson
           PolicyDocument:
@@ -1461,6 +1464,7 @@ Resources:
               Resource:
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-vc-signing-key"
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-encryption-key"
+      Role: !GetAtt JWKSBucketRole.Arn
       Events:
         InvocationLevel:
           Type: Schedule

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1447,12 +1447,18 @@ Resources:
         - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
+      Tags:
+        key_consumer_type: manage
       Policies:
         - AWSXRayDaemonWriteAccess
+        - S3ReadPolicy:
+            BucketName: !Ref JsonWebKeysBucket
         - S3WritePolicy:
             BucketName: !Ref JsonWebKeysBucket
         - S3ReadPolicy:
-            BucketName: !Ref JsonWebKeysBucket
+            BucketName: !Sub "govuk-one-login-cic-published-keys-${Environment}"
+        - S3WritePolicy:
+            BucketName: !Sub "govuk-one-login-cic-published-keys-${Environment}"
         - Statement:
             - Sid: KMSSignPolicy
               Effect: Allow
@@ -1470,6 +1476,8 @@ Resources:
       Environment:
         Variables:
           JWKS_BUCKET_NAME: !Ref JsonWebKeysBucket
+          PUBLISHED_KEYS_BUCKET_NAME: !Sub "govuk-one-login-cic-published-keys-${Environment}"
+          BACKEND_URL: !Sub "https://api-${AWS::StackName}.review-c.${Environment}.account.gov.uk"
           SIGNING_KEY_IDS:
             Fn::ImportValue: !Sub "${L2KMSStackName}-vc-signing-key"
           ENCRYPTION_KEY_IDS:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -512,6 +512,11 @@ Resources:
                   - "s3:Get*"
                 Resource:
                   - !Sub "arn:aws:s3:::${JsonWebKeysBucket}/.well-known/jwks.json"
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                Resource:
+                  - !Sub "arn:aws:s3:::govuk-one-login-cic-published-keys-${Environment}/.well-known/jwks.json"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -502,9 +502,6 @@ Resources:
             Principal:
               Service: apigateway.amazonaws.com
         Version: 2012-10-17
-      Tags:
-        - Key: key_consumer_type
-        - Value: manage
       Policies:
         - PolicyName: AccessJWKSjson
           PolicyDocument:
@@ -1464,7 +1461,6 @@ Resources:
               Resource:
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-vc-signing-key"
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-encryption-key"
-      Role: !GetAtt JWKSBucketRole.Arn
       Events:
         InvocationLevel:
           Type: Schedule


### PR DESCRIPTION
### What changed

Implemented copyKeys method in JwksHandler lambda to copy keys from existing jwks bucket to new published keys shared infra bucket, and pointed well-known endpoint to new jwks/json folder

### Why did it change

To facilitate key rotation initiative 

### Issue tracking

- [KIWI-2306](https://govukverify.atlassian.net/browse/KIWI-2306)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository
