### PR TITLE
[KIWI-2306] - CIC | OAuth | Move public encryption keys to new S3

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1471,8 +1471,7 @@ Resources:
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-vc-signing-key"
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-encryption-key"
       Tags:
-          Key: "key_consumer_type"
-          Value: "manage"
+        key_consumer_type: manage
       Events:
         InvocationLevel:
           Type: Schedule


### PR DESCRIPTION
### What changed

S3 bucket policy fix

### Issue tracking

- [KIWI-2306](https://govukverify.atlassian.net/browse/KIWI-2306)

### Evidence

![image](https://github.com/user-attachments/assets/6cf2e737-aa6a-4843-863a-765f642ea7c5)

![image](https://github.com/user-attachments/assets/2dd6b9d7-963c-4315-96e6-fe597e817e87)



[KIWI-2306]: https://govukverify.atlassian.net/browse/KIWI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ