### PR TITLE
KIWI-2370 - Verify new S3 bucket and connect to existing JWKS endpoint

### DIFF
--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -582,6 +582,86 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws"
+
+  /.well-known-test/jwks.json:
+    get:
+      operationId: getWellKnownTestJwksJson
+      summary: Return the contents of the published-keys bucket
+      tags:
+        - Backend - CIC CRI specific
+      responses:
+        "200":
+          description: >-
+            OK - key ring returned
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSFile"
+        "400":
+          description: 400 response
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+        "500":
+          description: Internal Server Error
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+      x-amazon-apigateway-request-validator: "both"
+      x-amazon-apigateway-integration:
+        httpMethod: "GET"
+        credentials:
+          Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-cic-published-keys-${Environment}/jwks.json"
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws"
   
   /session-config:
     get:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -521,6 +521,9 @@ Resources:
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
+      Tags:
+        - Key: key_consumer_type
+          Value: manage
 
   LambdaDeployRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
### What changed

Added a new temporary APIGW endpoint that integrates with the new `published-keys` bucket.

### Why did it change

The sole purpose of this endpoint is to confirm the contents of the new `published-keys` bucket, which is published to alongside the existing `JsonWebKeysBucket`. This cannot be done via the AWS console due to restrictions applied on the new bucket. Once the contents are confirmed, this endpoint should be removed in a followup PR that integrates the new bucket with the existing `well-known `e/p.

### Issue tracking

- [KIWI-2370](https://govukverify.atlassian.net/browse/KIWI-2370)
<img width="1667" height="367" alt="image" src="https://github.com/user-attachments/assets/a501c46d-9808-4823-871e-c19106ba1b43" />

<img width="1566" height="159" alt="image" src="https://github.com/user-attachments/assets/acd5cc22-3a94-4966-8ff4-2909ba6ad84d" />

[KIWI-2370]: https://govukverify.atlassian.net/browse/KIWI-2370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ