### PR TITLE
Disable JsonWebKeysFunction scheduled invocation

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1482,11 +1482,12 @@ Resources:
                 - Fn::ImportValue: !Sub "${L2KMSStackName}-encryption-key"
       Tags:
         key_consumer_type: manage
-      Events:
-        InvocationLevel:
-          Type: Schedule
-          Properties:
-            Schedule: cron(0 * * * ? *)
+      # Disabled as CIC CRI now uses keys published by key rotation on the ./well-known e/p
+      # Events:
+      #   InvocationLevel:
+      #     Type: Schedule
+      #     Properties:
+      #       Schedule: cron(0 * * * ? *)
 
       Environment:
         Variables:


### PR DESCRIPTION
### What changed

Disabled JsonWebKeysFunction scheduled invocation

### Why did it change

To prevent the lambda publishing JWKs to the S3 bucket used by the ./well-known endpoint, as this action overwrites keys published by the key rotation stack to the same bucket

