### PR TITLE
[KIWI-2476] - CIC | Add FMS tags for custom WAF policy migration in lower environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -207,6 +207,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsDevOrBuildOrStaging: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -611,8 +615,8 @@ Resources:
         Service: backend
         Name: CICRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   CICAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
### What changed

Added Firewall Manager (FMS) tags to template file

### Why did it change

To accommodate a transition from COUNT (logging rule violations) to BLOCK (actively blocking rule violations) in the lower environments

### Issue tracking
- [KIWI-2476](https://govukverify.atlassian.net/browse/KIWI-2476)

#### Tags in Stages

<img width="735" height="483" alt="Screenshot 2025-10-02 at 17 02 20" src="https://github.com/user-attachments/assets/f2765d9f-495f-4d63-8f4a-153a544ed258" />

